### PR TITLE
Fix IntegrityVerifier: treat size=0 as unknown, skip empty SHA256

### DIFF
--- a/samples/SampleModelPackage.BgeEmbedding/model-manifest.json
+++ b/samples/SampleModelPackage.BgeEmbedding/model-manifest.json
@@ -6,7 +6,7 @@
       {
         "path": "onnx/model.onnx",
         "sha256": "",
-        "size": null
+        "size": 0
       }
     ]
   },

--- a/samples/SampleModelPackage.Classification/model-manifest.json
+++ b/samples/SampleModelPackage.Classification/model-manifest.json
@@ -6,7 +6,7 @@
       {
         "path": "onnx/model.onnx",
         "sha256": "",
-        "size": null
+        "size": 0
       }
     ]
   },

--- a/samples/SampleModelPackage.E5Embedding/model-manifest.json
+++ b/samples/SampleModelPackage.E5Embedding/model-manifest.json
@@ -6,7 +6,7 @@
       {
         "path": "onnx/model.onnx",
         "sha256": "",
-        "size": null
+        "size": 0
       }
     ]
   },

--- a/samples/SampleModelPackage.GteEmbedding/model-manifest.json
+++ b/samples/SampleModelPackage.GteEmbedding/model-manifest.json
@@ -6,7 +6,7 @@
       {
         "path": "onnx/model.onnx",
         "sha256": "",
-        "size": null
+        "size": 0
       }
     ]
   },

--- a/samples/SampleModelPackage.NER/model-manifest.json
+++ b/samples/SampleModelPackage.NER/model-manifest.json
@@ -6,7 +6,7 @@
       {
         "path": "onnx/model.onnx",
         "sha256": "",
-        "size": null
+        "size": 0
       }
     ]
   },

--- a/samples/SampleModelPackage.QA/model-manifest.json
+++ b/samples/SampleModelPackage.QA/model-manifest.json
@@ -6,7 +6,7 @@
       {
         "path": "onnx/model.onnx",
         "sha256": "",
-        "size": null
+        "size": 0
       }
     ]
   },

--- a/samples/SampleModelPackage.Reranking/model-manifest.json
+++ b/samples/SampleModelPackage.Reranking/model-manifest.json
@@ -6,7 +6,7 @@
       {
         "path": "onnx/model.onnx",
         "sha256": "",
-        "size": null
+        "size": 0
       }
     ]
   },

--- a/samples/SampleModelPackage.TextGeneration/model-manifest.json
+++ b/samples/SampleModelPackage.TextGeneration/model-manifest.json
@@ -6,7 +6,7 @@
       {
         "path": "cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4/phi3-mini-4k-instruct-cpu-int4-rtn-block-32-acc-level-4.onnx",
         "sha256": "",
-        "size": null
+        "size": 0
       }
     ]
   },

--- a/src/ModelPackages/ModelPackage.cs
+++ b/src/ModelPackages/ModelPackage.cs
@@ -74,7 +74,7 @@ public sealed class ModelPackage
             await ModelCache.AtomicWriteAsync(cachePath, async tempPath =>
             {
                 await ModelDownloader.DownloadAsync(url, tempPath, options, cancellationToken);
-                await IntegrityVerifier.VerifyAsync(tempPath, file.Sha256, file.Size, cancellationToken);
+                await IntegrityVerifier.VerifyAsync(tempPath, file.Sha256, file.Size, cancellationToken, log);
             }, cancellationToken);
         }
 
@@ -115,7 +115,7 @@ public sealed class ModelPackage
     {
         var file = _manifest.Model.Files[0];
         var cachePath = ModelCache.GetCachePath(_manifest, file, options);
-        await IntegrityVerifier.VerifyAsync(cachePath, file.Sha256, file.Size, cancellationToken);
+        await IntegrityVerifier.VerifyAsync(cachePath, file.Sha256, file.Size, cancellationToken, options?.Logger);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes #11  `IntegrityVerifier` throws `Size mismatch` when a manifest has `"size": 0`, because 0 is treated as "expect exactly 0 bytes" instead of "unknown/skip".

## Changes

### IntegrityVerifier.cs

**Size check** (`VerifyAsync` + `IsValidAsync`):
- Before: `if (expectedSize.HasValue)`  0 triggers validation
- After: `if (expectedSize.HasValue && expectedSize.Value > 0)`  0 skips validation

**SHA256 check** (`VerifyAsync`):
- Before: empty `sha256` always fails (empty string never matches real hash, file gets deleted after download)
- After: empty/null `sha256` skips verification with a logged warning

**SHA256 check** (`IsValidAsync`):
- Empty/null `sha256` returns `false` (forces re-download, then `VerifyAsync` handles the skip-with-warning)

### Manifests

Updated 8 new sample manifests: `"size": null`  `"size": 0` (explicit "unknown", now handled correctly).

## Behavior Matrix

| `sha256` | `size` | Behavior |
|---|---|---|
| `"abc123..."` | `90405214` | Full verification (existing) |
| `"abc123..."` | `null` or `0` | SHA256 only, size skipped |
| `""` | any | Skip all verification + log warning |
| `null` | any | Skip all verification + log warning |
