### PR TITLE
ExtractResources respects cache directory overrides

### DIFF
--- a/src/ModelPackages/ModelCache.cs
+++ b/src/ModelPackages/ModelCache.cs
@@ -36,7 +36,7 @@ internal static class ModelCache
         }
     }
 
-    private static string ResolveCacheDir(ModelOptions? options)
+    internal static string ResolveCacheDir(ModelOptions? options)
     {
         // 1. ModelOptions.CacheDirOverride
         if (!string.IsNullOrEmpty(options?.CacheDirOverride))

--- a/src/ModelPackages/ModelPackage.cs
+++ b/src/ModelPackages/ModelPackage.cs
@@ -124,12 +124,24 @@ public sealed class ModelPackage
 
     /// <summary>
     /// Extracts embedded resources matching the given file patterns from an assembly
-    /// to a model-specific cache directory.
+    /// to a model-specific cache directory, using the default cache location.
     /// Returns the directory path containing the extracted files.
     /// </summary>
     public static string ExtractResources(
         Assembly assembly,
         string modelName,
+        string[]? filePatterns = null)
+        => ExtractResources(assembly, modelName, options: null, filePatterns);
+
+    /// <summary>
+    /// Extracts embedded resources matching the given file patterns from an assembly
+    /// to a model-specific cache directory, respecting cache directory overrides in <paramref name="options"/>.
+    /// Returns the directory path containing the extracted files.
+    /// </summary>
+    public static string ExtractResources(
+        Assembly assembly,
+        string modelName,
+        ModelOptions? options,
         string[]? filePatterns = null)
     {
         ArgumentNullException.ThrowIfNull(modelName);
@@ -138,8 +150,8 @@ public sealed class ModelPackage
 
         filePatterns ??= DefaultResourcePatterns;
 
-        var cacheDir = Path.Combine(
-            ModelCache.GetDefaultCacheDir(), "resource-cache", modelName);
+        var baseCacheDir = ModelCache.ResolveCacheDir(options);
+        var cacheDir = Path.Combine(baseCacheDir, "resource-cache", modelName);
         Directory.CreateDirectory(cacheDir);
 
         foreach (var resourceName in assembly.GetManifestResourceNames())


### PR DESCRIPTION
Closes #17

## Summary
Makes \ExtractResources\ honor \ModelOptions.CacheDirOverride\ so consumers can control where resource files are extracted.

## Changes
- \ModelCache.ResolveCacheDir\ changed from \private\ to \internal\
- Added new \ExtractResources\ overload accepting \ModelOptions?\
- Existing overload delegates to the new one with \options: null\ (no behavior change)

## Testing
- Builds with 0 warnings, 0 errors
