### PR TITLE
Add unit test suite with mock HTTP server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Build
         run: dotnet build -c Release --no-restore
 
+      - name: Test
+        run: dotnet test -c Release --no-build --logger "console;verbosity=normal"
+
       # Determine version: tag-based for releases, preview for main
       - name: Set version
         id: version

--- a/ModelPackages.slnx
+++ b/ModelPackages.slnx
@@ -3,6 +3,9 @@
     <Project Path="src/ModelPackages/ModelPackages.csproj" />
     <Project Path="src/ModelPackages.Tool/ModelPackages.Tool.csproj" />
   </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/ModelPackages.Tests/ModelPackages.Tests.csproj" />
+  </Folder>
   <Folder Name="/samples/onnx/">
     <Project Path="samples/SampleModelPackage.Onnx/SampleModelPackage.Onnx.csproj" />
     <Project Path="samples/SampleConsumer.Onnx/SampleConsumer.Onnx.csproj" />

--- a/src/ModelPackages/ModelPackages.csproj
+++ b/src/ModelPackages/ModelPackages.csproj
@@ -14,4 +14,8 @@
     <None Include="PACKAGE.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="ModelPackages.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/tests/ModelPackages.Tests/AtomicWriteTests.cs
+++ b/tests/ModelPackages.Tests/AtomicWriteTests.cs
@@ -1,0 +1,110 @@
+using Xunit;
+
+namespace ModelPackages.Tests;
+
+public class AtomicWriteTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public AtomicWriteTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "aw-test-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public async Task AtomicWrite_Success_FileExistsAtFinalPath()
+    {
+        var finalPath = Path.Combine(_tempDir, "model.bin");
+        var content = new byte[] { 1, 2, 3, 4, 5 };
+
+        await ModelCache.AtomicWriteAsync(finalPath, async tempPath =>
+        {
+            await File.WriteAllBytesAsync(tempPath, content);
+        }, CancellationToken.None);
+
+        Assert.True(File.Exists(finalPath));
+        Assert.Equal(content, await File.ReadAllBytesAsync(finalPath));
+    }
+
+    [Fact]
+    public async Task AtomicWrite_Success_NoTempFilesRemain()
+    {
+        var finalPath = Path.Combine(_tempDir, "clean.bin");
+
+        await ModelCache.AtomicWriteAsync(finalPath, async tempPath =>
+        {
+            await File.WriteAllBytesAsync(tempPath, [42]);
+        }, CancellationToken.None);
+
+        var files = Directory.GetFiles(_tempDir);
+        Assert.Single(files);
+        Assert.Equal("clean.bin", Path.GetFileName(files[0]));
+    }
+
+    [Fact]
+    public async Task AtomicWrite_CallbackThrows_TempFileCleaned()
+    {
+        var finalPath = Path.Combine(_tempDir, "failed.bin");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await ModelCache.AtomicWriteAsync(finalPath, _ =>
+            {
+                throw new InvalidOperationException("download failed");
+            }, CancellationToken.None);
+        });
+
+        Assert.False(File.Exists(finalPath));
+        // No .partial files should remain
+        var partials = Directory.GetFiles(_tempDir, "*.partial.*");
+        Assert.Empty(partials);
+    }
+
+    [Fact]
+    public async Task AtomicWrite_CreatesDirectoryIfNeeded()
+    {
+        var nestedDir = Path.Combine(_tempDir, "org", "model", "v1");
+        var finalPath = Path.Combine(nestedDir, "model.bin");
+
+        await ModelCache.AtomicWriteAsync(finalPath, async tempPath =>
+        {
+            await File.WriteAllBytesAsync(tempPath, [1, 2, 3]);
+        }, CancellationToken.None);
+
+        Assert.True(File.Exists(finalPath));
+    }
+
+    [Fact]
+    public async Task AtomicWrite_OverwriteExisting_Succeeds()
+    {
+        var finalPath = Path.Combine(_tempDir, "overwrite.bin");
+        await File.WriteAllBytesAsync(finalPath, [1]);
+
+        await ModelCache.AtomicWriteAsync(finalPath, async tempPath =>
+        {
+            await File.WriteAllBytesAsync(tempPath, [2, 3, 4]);
+        }, CancellationToken.None);
+
+        Assert.Equal([2, 3, 4], await File.ReadAllBytesAsync(finalPath));
+    }
+
+    [Fact]
+    public async Task AcquireLock_AndRelease_Works()
+    {
+        var lockTarget = Path.Combine(_tempDir, "locktest.bin");
+
+        using (var lk = await ModelCache.AcquireLockAsync(lockTarget, CancellationToken.None))
+        {
+            Assert.True(File.Exists(lockTarget + ".lock"));
+        }
+
+        // Lock file is cleaned up after dispose
+        Assert.False(File.Exists(lockTarget + ".lock"));
+    }
+}

--- a/tests/ModelPackages.Tests/CacheTests.cs
+++ b/tests/ModelPackages.Tests/CacheTests.cs
@@ -1,0 +1,115 @@
+using Xunit;
+
+namespace ModelPackages.Tests;
+
+public class CacheTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string? _prevEnvDir;
+
+    public CacheTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "modelpackages-test-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+        _prevEnvDir = Environment.GetEnvironmentVariable("MODELPACKAGES_CACHE_DIR");
+        Environment.SetEnvironmentVariable("MODELPACKAGES_CACHE_DIR", null);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("MODELPACKAGES_CACHE_DIR", _prevEnvDir);
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    private static ModelManifest CreateManifest(string modelId = "test/model", string revision = "main", string filePath = "model.onnx")
+    {
+        var json = $$"""
+        {
+          "model": {
+            "id": "{{modelId}}",
+            "revision": "{{revision}}",
+            "files": [{ "path": "{{filePath}}", "sha256": "abc", "size": 1024 }]
+          },
+          "sources": { "hf": { "type": "huggingface" } },
+          "defaultSource": "hf"
+        }
+        """;
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json));
+        return ModelManifest.FromStream(stream);
+    }
+
+    [Fact]
+    public void GetCachePath_CorrectStructure()
+    {
+        var manifest = CreateManifest();
+        var file = manifest.Model.Files[0];
+        var options = new ModelOptions { CacheDirOverride = _tempDir };
+
+        var path = ModelCache.GetCachePath(manifest, file, options);
+
+        Assert.Equal(Path.Combine(_tempDir, "test", "model", "main", "model.onnx"), path);
+    }
+
+    [Fact]
+    public void GetCachePath_ModelIdWithSlashes_CreatesSubdirectories()
+    {
+        var manifest = CreateManifest(modelId: "org/sub/deep-model");
+        var file = manifest.Model.Files[0];
+        var options = new ModelOptions { CacheDirOverride = _tempDir };
+
+        var path = ModelCache.GetCachePath(manifest, file, options);
+
+        Assert.Equal(
+            Path.Combine(_tempDir, "org", "sub", "deep-model", "main", "model.onnx"),
+            path);
+    }
+
+    [Fact]
+    public void GetCachePath_CacheDirOverride_UsesOverride()
+    {
+        var manifest = CreateManifest();
+        var file = manifest.Model.Files[0];
+        var customDir = Path.Combine(_tempDir, "custom-cache");
+        var options = new ModelOptions { CacheDirOverride = customDir };
+
+        var path = ModelCache.GetCachePath(manifest, file, options);
+
+        Assert.StartsWith(customDir, path);
+    }
+
+    [Fact]
+    public void GetCachePath_EnvVarOverride_UsesEnvVar()
+    {
+        var envDir = Path.Combine(_tempDir, "env-cache");
+        Environment.SetEnvironmentVariable("MODELPACKAGES_CACHE_DIR", envDir);
+
+        var manifest = CreateManifest();
+        var file = manifest.Model.Files[0];
+
+        var path = ModelCache.GetCachePath(manifest, file, options: null);
+
+        Assert.StartsWith(envDir, path);
+    }
+
+    [Fact]
+    public void GetDefaultCacheDir_ReturnsNonEmpty()
+    {
+        var dir = ModelCache.GetDefaultCacheDir();
+
+        Assert.NotNull(dir);
+        Assert.NotEmpty(dir);
+        Assert.True(Path.IsPathRooted(dir));
+    }
+
+    [Fact]
+    public void GetCachePath_CustomRevision_IncludedInPath()
+    {
+        var manifest = CreateManifest(revision: "v2.1");
+        var file = manifest.Model.Files[0];
+        var options = new ModelOptions { CacheDirOverride = _tempDir };
+
+        var path = ModelCache.GetCachePath(manifest, file, options);
+
+        Assert.Contains("v2.1", path);
+    }
+}

--- a/tests/ModelPackages.Tests/DownloaderTests.cs
+++ b/tests/ModelPackages.Tests/DownloaderTests.cs
@@ -1,0 +1,146 @@
+using System.Security.Cryptography;
+using ModelPackages.Tests.Helpers;
+using Xunit;
+
+namespace ModelPackages.Tests;
+
+public class DownloaderTests : IAsyncLifetime
+{
+    private MockModelServer _server = null!;
+    private string _tempDir = null!;
+
+    public async Task InitializeAsync()
+    {
+        _server = new MockModelServer();
+        _tempDir = Path.Combine(Path.GetTempPath(), "dl-test-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+        await Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _server.DisposeAsync();
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    private string TempFile(string name = "downloaded.bin") => Path.Combine(_tempDir, name);
+
+    [Fact]
+    public async Task Download_Success_FileMatchesContent()
+    {
+        var content = new byte[1024];
+        Random.Shared.NextBytes(content);
+        _server.AddFile("models/test.bin", content);
+
+        var dest = TempFile();
+        await ModelDownloader.DownloadAsync(
+            $"{_server.BaseUrl}/models/test.bin",
+            dest,
+            options: null,
+            CancellationToken.None);
+
+        Assert.True(File.Exists(dest));
+        Assert.Equal(content, await File.ReadAllBytesAsync(dest));
+    }
+
+    [Fact]
+    public async Task Download_Http404_ThrowsWithMessage()
+    {
+        var dest = TempFile();
+
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            ModelDownloader.DownloadAsync(
+                $"{_server.BaseUrl}/nonexistent",
+                dest,
+                options: null,
+                CancellationToken.None));
+
+        Assert.Contains("404", ex.Message);
+    }
+
+    [Fact]
+    public async Task Download_Http500ThenSuccess_RetriesAndSucceeds()
+    {
+        var content = new byte[] { 1, 2, 3, 4, 5 };
+        _server.AddFile("models/retry.bin", content, failCount: 1, failStatusCode: 500);
+
+        var dest = TempFile();
+        await ModelDownloader.DownloadAsync(
+            $"{_server.BaseUrl}/models/retry.bin",
+            dest,
+            options: null,
+            CancellationToken.None);
+
+        Assert.Equal(content, await File.ReadAllBytesAsync(dest));
+    }
+
+    [Fact]
+    public async Task Download_FileUrl_CopiesLocalFile()
+    {
+        var sourceFile = Path.Combine(_tempDir, "source-model.bin");
+        var content = new byte[] { 10, 20, 30, 40, 50 };
+        await File.WriteAllBytesAsync(sourceFile, content);
+
+        var dest = TempFile("copied.bin");
+        var fileUrl = new Uri(sourceFile).AbsoluteUri;
+
+        await ModelDownloader.DownloadAsync(fileUrl, dest, options: null, CancellationToken.None);
+
+        Assert.Equal(content, await File.ReadAllBytesAsync(dest));
+    }
+
+    [Fact]
+    public async Task Download_HfToken_SentAsBearerAuth()
+    {
+        var content = new byte[] { 1 };
+        _server.AddFile("models/private.bin", content);
+
+        var dest = TempFile();
+        var options = new ModelOptions { HuggingFaceToken = "hf_test_token_123" };
+
+        await ModelDownloader.DownloadAsync(
+            $"{_server.BaseUrl}/models/private.bin",
+            dest,
+            options,
+            CancellationToken.None);
+
+        var req = _server.Requests.Last();
+        Assert.Contains("Bearer hf_test_token_123", req.AuthorizationHeader);
+    }
+
+    [Fact]
+    public async Task Download_LoggerCallback_ReceivesMessages()
+    {
+        var content = new byte[1024];
+        _server.AddFile("models/logged.bin", content);
+
+        var messages = new List<string>();
+        var options = new ModelOptions { Logger = msg => messages.Add(msg) };
+
+        var dest = TempFile();
+        await ModelDownloader.DownloadAsync(
+            $"{_server.BaseUrl}/models/logged.bin",
+            dest,
+            options,
+            CancellationToken.None);
+
+        Assert.Contains(messages, m => m.Contains("Downloading"));
+        Assert.Contains(messages, m => m.Contains("complete"));
+    }
+
+    [Fact]
+    public async Task Download_Http429ThenSuccess_RetriesAndSucceeds()
+    {
+        var content = new byte[] { 42 };
+        _server.AddFile("models/rate-limited.bin", content, failCount: 1, failStatusCode: 429);
+
+        var dest = TempFile();
+        await ModelDownloader.DownloadAsync(
+            $"{_server.BaseUrl}/models/rate-limited.bin",
+            dest,
+            options: null,
+            CancellationToken.None);
+
+        Assert.Equal(content, await File.ReadAllBytesAsync(dest));
+    }
+}

--- a/tests/ModelPackages.Tests/Fixtures/multi-file-manifest.json
+++ b/tests/ModelPackages.Tests/Fixtures/multi-file-manifest.json
@@ -1,0 +1,29 @@
+{
+  "model": {
+    "id": "org/sharded-model",
+    "revision": "v1.0",
+    "files": [
+      {
+        "path": "model-00001-of-00003.onnx",
+        "sha256": "aaaa",
+        "size": 500000000
+      },
+      {
+        "path": "model-00002-of-00003.onnx",
+        "sha256": "bbbb",
+        "size": 500000000
+      },
+      {
+        "path": "tokenizer.json",
+        "sha256": "cccc",
+        "size": 712000
+      }
+    ]
+  },
+  "sources": {
+    "huggingface": {
+      "type": "huggingface"
+    }
+  },
+  "defaultSource": "huggingface"
+}

--- a/tests/ModelPackages.Tests/Fixtures/no-size-manifest.json
+++ b/tests/ModelPackages.Tests/Fixtures/no-size-manifest.json
@@ -1,0 +1,19 @@
+{
+  "model": {
+    "id": "test/no-size-model",
+    "revision": "main",
+    "files": [
+      {
+        "path": "model.onnx",
+        "sha256": "",
+        "size": 0
+      }
+    ]
+  },
+  "sources": {
+    "huggingface": {
+      "type": "huggingface"
+    }
+  },
+  "defaultSource": "huggingface"
+}

--- a/tests/ModelPackages.Tests/Fixtures/valid-manifest.json
+++ b/tests/ModelPackages.Tests/Fixtures/valid-manifest.json
@@ -1,0 +1,29 @@
+{
+  "model": {
+    "id": "sentence-transformers/all-MiniLM-L6-v2",
+    "revision": "main",
+    "files": [
+      {
+        "path": "onnx/model.onnx",
+        "sha256": "6fd5d72fe4589f189f8ebc006442dbb529bb7ce38f8082112682524616046452",
+        "size": 90405214
+      }
+    ]
+  },
+  "sources": {
+    "huggingface": {
+      "type": "huggingface",
+      "repo": "sentence-transformers/all-MiniLM-L6-v2",
+      "revision": "main"
+    },
+    "corp-mirror": {
+      "type": "mirror",
+      "endpoint": "https://models.internal.corp.com"
+    },
+    "direct-url": {
+      "type": "direct",
+      "url": "https://example.com/model.onnx"
+    }
+  },
+  "defaultSource": "huggingface"
+}

--- a/tests/ModelPackages.Tests/Helpers/MockModelServer.cs
+++ b/tests/ModelPackages.Tests/Helpers/MockModelServer.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace ModelPackages.Tests.Helpers;
+
+/// <summary>
+/// Lightweight in-process HTTP server for deterministic, offline download tests.
+/// </summary>
+internal sealed class MockModelServer : IAsyncDisposable
+{
+    private readonly WebApplication _app;
+    private readonly Dictionary<string, FileEntry> _files = new(StringComparer.OrdinalIgnoreCase);
+    private readonly List<RequestRecord> _requests = [];
+
+    public string BaseUrl { get; }
+    public IReadOnlyList<RequestRecord> Requests => _requests;
+
+    public MockModelServer()
+    {
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.WebHost.ConfigureKestrel(k => k.Listen(IPAddress.Loopback, 0));
+        _app = builder.Build();
+
+        _app.MapGet("/{**path}", (HttpContext ctx) =>
+        {
+            var path = ctx.Request.Path.Value?.TrimStart('/') ?? "";
+            _requests.Add(new RequestRecord(path, ctx.Request.Headers.Authorization.ToString()));
+
+            if (!_files.TryGetValue(path, out var entry))
+                return Results.NotFound($"File not found: {path}");
+
+            if (entry.FailCount > 0)
+            {
+                entry.FailCount--;
+                return Results.StatusCode(entry.FailStatusCode);
+            }
+
+            return Results.Bytes(entry.Content, "application/octet-stream");
+        });
+
+        _app.Start();
+        var addresses = _app.Services.GetRequiredService<IServer>()
+            .Features.Get<IServerAddressesFeature>()!;
+        BaseUrl = addresses.Addresses.First();
+    }
+
+    /// <summary>Register a file to serve at the given path.</summary>
+    public void AddFile(string path, byte[] content)
+    {
+        _files[path] = new FileEntry(content);
+    }
+
+    /// <summary>Register a file that fails the first N requests, then succeeds.</summary>
+    public void AddFile(string path, byte[] content, int failCount, int failStatusCode = 500)
+    {
+        _files[path] = new FileEntry(content) { FailCount = failCount, FailStatusCode = failStatusCode };
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _app.DisposeAsync();
+    }
+
+    private sealed class FileEntry(byte[] content)
+    {
+        public byte[] Content { get; } = content;
+        public int FailCount { get; set; }
+        public int FailStatusCode { get; set; } = 500;
+    }
+
+    internal sealed record RequestRecord(string Path, string AuthorizationHeader);
+}

--- a/tests/ModelPackages.Tests/IntegrityVerifierTests.cs
+++ b/tests/ModelPackages.Tests/IntegrityVerifierTests.cs
@@ -1,0 +1,165 @@
+using System.Security.Cryptography;
+using System.Text;
+using Xunit;
+
+namespace ModelPackages.Tests;
+
+public class IntegrityVerifierTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public IntegrityVerifierTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "iv-test-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    private string CreateTestFile(string content = "test model content")
+    {
+        var path = Path.Combine(_tempDir, Guid.NewGuid().ToString("N") + ".bin");
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private static string ComputeSha256(string filePath)
+    {
+        using var sha256 = SHA256.Create();
+        using var stream = File.OpenRead(filePath);
+        return Convert.ToHexString(sha256.ComputeHash(stream)).ToLowerInvariant();
+    }
+
+    [Fact]
+    public async Task VerifyAsync_ValidFile_Passes()
+    {
+        var filePath = CreateTestFile();
+        var expectedHash = ComputeSha256(filePath);
+        var expectedSize = new FileInfo(filePath).Length;
+
+        // Should not throw
+        await IntegrityVerifier.VerifyAsync(filePath, expectedHash, expectedSize, CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WrongSha256_ThrowsAndDeletesFile()
+    {
+        var filePath = CreateTestFile();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            IntegrityVerifier.VerifyAsync(filePath, "0000000000000000000000000000000000000000000000000000000000000000", null, CancellationToken.None));
+
+        Assert.Contains("SHA256 mismatch", ex.Message);
+        Assert.False(File.Exists(filePath));
+    }
+
+    [Fact]
+    public async Task VerifyAsync_WrongSize_ThrowsAndDeletesFile()
+    {
+        var filePath = CreateTestFile();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            IntegrityVerifier.VerifyAsync(filePath, "unused", 999999L, CancellationToken.None));
+
+        Assert.Contains("Size mismatch", ex.Message);
+        Assert.False(File.Exists(filePath));
+    }
+
+    [Fact]
+    public async Task VerifyAsync_SizeZero_SkipsSizeCheck()
+    {
+        var filePath = CreateTestFile("some content");
+        var expectedHash = ComputeSha256(filePath);
+
+        // size=0 should be treated as "unknown" — skip size validation
+        await IntegrityVerifier.VerifyAsync(filePath, expectedHash, 0L, CancellationToken.None);
+
+        Assert.True(File.Exists(filePath));
+    }
+
+    [Fact]
+    public async Task VerifyAsync_EmptySha256_SkipsWithWarning()
+    {
+        var filePath = CreateTestFile();
+        var warnings = new List<string>();
+
+        await IntegrityVerifier.VerifyAsync(filePath, "", null, CancellationToken.None,
+            log: msg => warnings.Add(msg));
+
+        Assert.True(File.Exists(filePath));
+        Assert.Contains(warnings, w => w.Contains("No SHA256 hash"));
+    }
+
+    [Fact]
+    public async Task VerifyAsync_NullSha256_SkipsWithWarning()
+    {
+        var filePath = CreateTestFile();
+        var warnings = new List<string>();
+
+        await IntegrityVerifier.VerifyAsync(filePath, null!, null, CancellationToken.None,
+            log: msg => warnings.Add(msg));
+
+        Assert.True(File.Exists(filePath));
+        Assert.Contains(warnings, w => w.Contains("No SHA256 hash"));
+    }
+
+    [Fact]
+    public async Task VerifyAsync_FileNotFound_ThrowsFileNotFoundException()
+    {
+        await Assert.ThrowsAsync<FileNotFoundException>(() =>
+            IntegrityVerifier.VerifyAsync(
+                Path.Combine(_tempDir, "nonexistent.bin"),
+                "abc",
+                null,
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task IsValidAsync_ValidFile_ReturnsTrue()
+    {
+        var filePath = CreateTestFile();
+        var expectedHash = ComputeSha256(filePath);
+        var expectedSize = new FileInfo(filePath).Length;
+
+        var result = await IntegrityVerifier.IsValidAsync(filePath, expectedHash, expectedSize, CancellationToken.None);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task IsValidAsync_MissingFile_ReturnsFalse()
+    {
+        var result = await IntegrityVerifier.IsValidAsync(
+            Path.Combine(_tempDir, "nonexistent.bin"),
+            "abc",
+            null,
+            CancellationToken.None);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task IsValidAsync_EmptySha256_ReturnsFalse()
+    {
+        var filePath = CreateTestFile();
+
+        var result = await IntegrityVerifier.IsValidAsync(filePath, "", null, CancellationToken.None);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ComputeSha256Async_EmptyFile_ReturnsValidHash()
+    {
+        var filePath = Path.Combine(_tempDir, "empty.bin");
+        File.WriteAllBytes(filePath, []);
+
+        var hash = await IntegrityVerifier.ComputeSha256Async(filePath, CancellationToken.None);
+
+        // SHA256 of empty content is well-known
+        Assert.Equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", hash);
+    }
+}

--- a/tests/ModelPackages.Tests/ManifestTests.cs
+++ b/tests/ModelPackages.Tests/ManifestTests.cs
@@ -1,0 +1,123 @@
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace ModelPackages.Tests;
+
+public class ManifestTests
+{
+    private static string FixturePath(string name) =>
+        Path.Combine(AppContext.BaseDirectory, "Fixtures", name);
+
+    [Fact]
+    public void FromFile_ValidManifest_ParsesCorrectly()
+    {
+        var manifest = ModelManifest.FromFile(FixturePath("valid-manifest.json"));
+
+        Assert.Equal("sentence-transformers/all-MiniLM-L6-v2", manifest.Model.Id);
+        Assert.Equal("main", manifest.Model.Revision);
+        Assert.Single(manifest.Model.Files);
+        Assert.Equal("onnx/model.onnx", manifest.Model.Files[0].Path);
+        Assert.Equal("6fd5d72fe4589f189f8ebc006442dbb529bb7ce38f8082112682524616046452", manifest.Model.Files[0].Sha256);
+        Assert.Equal(90405214L, manifest.Model.Files[0].Size);
+        Assert.Equal("huggingface", manifest.DefaultSource);
+    }
+
+    [Fact]
+    public void FromFile_MultiFileManifest_AllFilesPresent()
+    {
+        var manifest = ModelManifest.FromFile(FixturePath("multi-file-manifest.json"));
+
+        Assert.Equal(3, manifest.Model.Files.Count);
+        Assert.Equal("model-00001-of-00003.onnx", manifest.Model.Files[0].Path);
+        Assert.Equal("model-00002-of-00003.onnx", manifest.Model.Files[1].Path);
+        Assert.Equal("tokenizer.json", manifest.Model.Files[2].Path);
+        Assert.Equal("v1.0", manifest.Model.Revision);
+    }
+
+    [Fact]
+    public void FromFile_SizeZero_ParsedAsZero()
+    {
+        var manifest = ModelManifest.FromFile(FixturePath("no-size-manifest.json"));
+
+        Assert.Equal(0L, manifest.Model.Files[0].Size);
+    }
+
+    [Fact]
+    public void FromStream_ValidJson_Succeeds()
+    {
+        var json = """
+        {
+          "model": {
+            "id": "test/model",
+            "revision": "main",
+            "files": [{ "path": "model.bin", "sha256": "abc123", "size": 1024 }]
+          },
+          "sources": { "hf": { "type": "huggingface" } },
+          "defaultSource": "hf"
+        }
+        """;
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+
+        var manifest = ModelManifest.FromStream(stream);
+
+        Assert.Equal("test/model", manifest.Model.Id);
+        Assert.Equal(1024L, manifest.Model.Files[0].Size);
+    }
+
+    [Fact]
+    public void FromStream_InvalidJson_ThrowsJsonException()
+    {
+        using var stream = new MemoryStream("not json"u8.ToArray());
+
+        Assert.Throws<JsonException>(() => ModelManifest.FromStream(stream));
+    }
+
+    [Fact]
+    public void FromFile_NonExistent_ThrowsFileNotFound()
+    {
+        Assert.Throws<FileNotFoundException>(() =>
+            ModelManifest.FromFile("does-not-exist.json"));
+    }
+
+    [Fact]
+    public void FromFile_MultipleSources_AllParsed()
+    {
+        var manifest = ModelManifest.FromFile(FixturePath("valid-manifest.json"));
+
+        Assert.Equal(3, manifest.Sources.Count);
+        Assert.True(manifest.Sources.ContainsKey("huggingface"));
+        Assert.True(manifest.Sources.ContainsKey("corp-mirror"));
+        Assert.True(manifest.Sources.ContainsKey("direct-url"));
+        Assert.Equal("huggingface", manifest.Sources["huggingface"].Type);
+        Assert.Equal("mirror", manifest.Sources["corp-mirror"].Type);
+        Assert.Equal("https://models.internal.corp.com", manifest.Sources["corp-mirror"].Endpoint);
+    }
+
+    [Fact]
+    public void FromFile_SizeOmitted_NullSize()
+    {
+        var json = """
+        {
+          "model": {
+            "id": "test/model",
+            "revision": "main",
+            "files": [{ "path": "model.bin", "sha256": "abc" }]
+          },
+          "sources": { "hf": { "type": "huggingface" } },
+          "defaultSource": "hf"
+        }
+        """;
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tempFile, json);
+            var manifest = ModelManifest.FromFile(tempFile);
+            Assert.Null(manifest.Model.Files[0].Size);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+}

--- a/tests/ModelPackages.Tests/ModelPackages.Tests.csproj
+++ b/tests/ModelPackages.Tests/ModelPackages.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ModelPackages\ModelPackages.csproj" />
+  </ItemGroup>
+
+  <!-- ASP.NET Core for mock HTTP server in download tests -->
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Fixtures\**\*" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/tests/ModelPackages.Tests/SourceResolverTests.cs
+++ b/tests/ModelPackages.Tests/SourceResolverTests.cs
@@ -1,0 +1,147 @@
+using Xunit;
+
+namespace ModelPackages.Tests;
+
+public class SourceResolverTests
+{
+    private static ModelManifest LoadFixture() =>
+        ModelManifest.FromFile(Path.Combine(AppContext.BaseDirectory, "Fixtures", "valid-manifest.json"));
+
+    [Fact]
+    public void Resolve_NoOverrides_UsesManifestDefault()
+    {
+        var manifest = LoadFixture();
+        var file = manifest.Model.Files[0];
+
+        var (url, sourceName) = ModelSourceResolver.Resolve(manifest, file, options: null);
+
+        Assert.Equal("huggingface", sourceName);
+        Assert.Contains("huggingface.co", url);
+        Assert.Contains("sentence-transformers/all-MiniLM-L6-v2", url);
+        Assert.EndsWith("/onnx/model.onnx", url);
+    }
+
+    [Fact]
+    public void Resolve_OptionsSourceNamedSource_UsesThatSource()
+    {
+        var manifest = LoadFixture();
+        var file = manifest.Model.Files[0];
+        var options = new ModelOptions { Source = "corp-mirror" };
+
+        var (url, sourceName) = ModelSourceResolver.Resolve(manifest, file, options);
+
+        Assert.Equal("corp-mirror", sourceName);
+        Assert.StartsWith("https://models.internal.corp.com/", url);
+    }
+
+    [Fact]
+    public void Resolve_OptionsSourceDirectUrl_ReturnsUrlDirectly()
+    {
+        var manifest = LoadFixture();
+        var file = manifest.Model.Files[0];
+        var options = new ModelOptions { Source = "https://my-cdn.com/model.onnx" };
+
+        var (url, sourceName) = ModelSourceResolver.Resolve(manifest, file, options);
+
+        Assert.Equal("https://my-cdn.com/model.onnx", url);
+        Assert.Equal("options-direct", sourceName);
+    }
+
+    [Fact]
+    public void Resolve_OptionsSourceFileUrl_ReturnsFileUrl()
+    {
+        var manifest = LoadFixture();
+        var file = manifest.Model.Files[0];
+        var options = new ModelOptions { Source = "file:///tmp/model.onnx" };
+
+        var (url, _) = ModelSourceResolver.Resolve(manifest, file, options);
+
+        Assert.Equal("file:///tmp/model.onnx", url);
+    }
+
+    [Fact]
+    public void Resolve_EnvVarOverride_UsesEnvVar()
+    {
+        var manifest = LoadFixture();
+        var file = manifest.Model.Files[0];
+        var prevValue = Environment.GetEnvironmentVariable("MODELPACKAGES_SOURCE");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("MODELPACKAGES_SOURCE", "corp-mirror");
+
+            var (url, sourceName) = ModelSourceResolver.Resolve(manifest, file, options: null);
+
+            Assert.Equal("corp-mirror", sourceName);
+            Assert.StartsWith("https://models.internal.corp.com/", url);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MODELPACKAGES_SOURCE", prevValue);
+        }
+    }
+
+    [Fact]
+    public void Resolve_OptionsSourceTakesPriorityOverEnvVar()
+    {
+        var manifest = LoadFixture();
+        var file = manifest.Model.Files[0];
+        var prevValue = Environment.GetEnvironmentVariable("MODELPACKAGES_SOURCE");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("MODELPACKAGES_SOURCE", "corp-mirror");
+            var options = new ModelOptions { Source = "direct-url" };
+
+            var (url, sourceName) = ModelSourceResolver.Resolve(manifest, file, options);
+
+            Assert.Equal("direct-url", sourceName);
+            Assert.Equal("https://example.com/model.onnx", url);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MODELPACKAGES_SOURCE", prevValue);
+        }
+    }
+
+    [Fact]
+    public void Resolve_UnknownSourceName_ThrowsWithAvailableSources()
+    {
+        var manifest = LoadFixture();
+        var file = manifest.Model.Files[0];
+        var options = new ModelOptions { Source = "nonexistent-source" };
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            ModelSourceResolver.Resolve(manifest, file, options));
+
+        Assert.Contains("nonexistent-source", ex.Message);
+        Assert.Contains("huggingface", ex.Message);
+    }
+
+    [Fact]
+    public void Resolve_HuggingFaceSource_BuildsCorrectUrl()
+    {
+        var manifest = LoadFixture();
+        var file = manifest.Model.Files[0];
+
+        var (url, _) = ModelSourceResolver.Resolve(manifest, file, options: null);
+
+        Assert.Equal(
+            "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model.onnx",
+            url);
+    }
+
+    [Fact]
+    public void Resolve_MirrorSource_BuildsCorrectUrl()
+    {
+        var manifest = LoadFixture();
+        var file = manifest.Model.Files[0];
+        var options = new ModelOptions { Source = "corp-mirror" };
+
+        var (url, _) = ModelSourceResolver.Resolve(manifest, file, options);
+
+        Assert.Equal(
+            "https://models.internal.corp.com/sentence-transformers/all-MiniLM-L6-v2/onnx/model.onnx",
+            url);
+    }
+}


### PR DESCRIPTION
Closes #4

## Summary
Adds a comprehensive xUnit test project with **47 tests** covering all core SDK classes.

## Test Coverage
| Test Class | Tests | Coverage |
|---|---|---|
| ManifestTests | 8 | JSON parsing, multi-file, missing fields, error handling |
| SourceResolverTests | 9 | Source hierarchy, env var overrides, URL passthrough |
| CacheTests | 6 | Path computation, overrides, env vars, default paths |
| IntegrityVerifierTests | 11 | SHA256/size validation, skip logic, edge cases |
| DownloaderTests | 7 | HTTP success/failure/retry, file:// URLs, auth tokens, logging |
| AtomicWriteTests | 6 | Atomic rename, cleanup on failure, locking, directory creation |

## Infrastructure
- **MockModelServer**: In-process Kestrel HTTP server (dynamic port, request tracking, configurable failures)
- **Test fixtures**: \alid-manifest.json\, \multi-file-manifest.json\, \
o-size-manifest.json\
- **InternalsVisibleTo** for testing internal classes
- **CI updated** to run \dotnet test\ after build

## All 47 tests pass
\\\
Test summary: total: 47, failed: 0, succeeded: 47, skipped: 0
\\\
