### PR TITLE
Add resumable downloads with HTTP Range headers

### DIFF
--- a/src/ModelPackages/ModelCache.cs
+++ b/src/ModelPackages/ModelCache.cs
@@ -77,6 +77,38 @@ internal static class ModelCache
     }
 
     /// <summary>
+    /// Finds an existing partial download file for the given final path.
+    /// Returns the partial file path if found, null otherwise.
+    /// </summary>
+    public static string? FindPartialFile(string finalPath)
+    {
+        var dir = Path.GetDirectoryName(finalPath);
+        if (dir is null || !Directory.Exists(dir))
+            return null;
+
+        var baseName = Path.GetFileName(finalPath);
+        var partials = Directory.GetFiles(dir, baseName + ".partial.*");
+        // Return the largest partial file (most progress)
+        return partials
+            .OrderByDescending(p => new FileInfo(p).Length)
+            .FirstOrDefault();
+    }
+
+    /// <summary>Removes all partial files for the given final path.</summary>
+    public static void CleanPartialFiles(string finalPath)
+    {
+        var dir = Path.GetDirectoryName(finalPath);
+        if (dir is null || !Directory.Exists(dir))
+            return;
+
+        var baseName = Path.GetFileName(finalPath);
+        foreach (var partial in Directory.GetFiles(dir, baseName + ".partial.*"))
+        {
+            try { File.Delete(partial); } catch { }
+        }
+    }
+
+    /// <summary>
     /// Acquires an exclusive lock file for the given cache path.
     /// Returns an IDisposable that releases the lock when disposed.
     /// Uses exponential backoff up to the timeout.

--- a/src/ModelPackages/ModelDownloader.cs
+++ b/src/ModelPackages/ModelDownloader.cs
@@ -19,7 +19,8 @@ internal static class ModelDownloader
 
     /// <summary>
     /// Downloads a file from the given URL to the destination path using streaming.
-    /// Supports file:// URIs (local copy), HuggingFace bearer token auth, and retry with exponential backoff.
+    /// Supports file:// URIs (local copy), HuggingFace bearer token auth, retry with exponential backoff,
+    /// and resumable downloads via HTTP Range headers.
     /// </summary>
     public static async Task DownloadAsync(
         string url,
@@ -29,7 +30,7 @@ internal static class ModelDownloader
     {
         var log = options?.Logger ?? (_ => { });
 
-        // Handle file:// URIs as local file copy
+        // Handle file:// URIs as local file copy (no resume support)
         if (url.StartsWith("file://", StringComparison.OrdinalIgnoreCase))
         {
             var sourcePath = new Uri(url).LocalPath;
@@ -53,6 +54,7 @@ internal static class ModelDownloader
                 var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt));
                 log($"Download attempt {attempt} failed ({ex.Message}). Retrying in {delay.TotalSeconds}s...");
                 await Task.Delay(delay, ct);
+                // Partial file is preserved for resume on next attempt
             }
         }
     }
@@ -74,6 +76,18 @@ internal static class ModelDownloader
             request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
         }
 
+        // Resume support: if partial file exists, request remaining bytes
+        long existingBytes = 0;
+        if (File.Exists(destinationPath))
+        {
+            existingBytes = new FileInfo(destinationPath).Length;
+            if (existingBytes > 0)
+            {
+                request.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(existingBytes, null);
+                log($"Resuming download from byte {existingBytes}...");
+            }
+        }
+
         log($"Downloading from {RedactUrl(url)}...");
 
         using var response = await SharedClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
@@ -85,19 +99,42 @@ internal static class ModelDownloader
             {
                 401 or 403 => $"HTTP {statusCode}: Authentication failed. Set HF_TOKEN for private HF repos or override MODELPACKAGES_SOURCE.",
                 404 => $"HTTP {statusCode}: Model file not found at {RedactUrl(url)}. Check the manifest source configuration.",
+                416 => $"HTTP {statusCode}: Range not satisfiable for {RedactUrl(url)}. Partial file may be corrupt.",
                 _ => $"HTTP {statusCode}: Download failed from {RedactUrl(url)}."
             };
+
+            // If Range request fails (416), delete partial and the caller's retry will start fresh
+            if (statusCode == 416 && File.Exists(destinationPath))
+            {
+                File.Delete(destinationPath);
+            }
+
             throw new HttpRequestException(message, null, response.StatusCode);
         }
 
+        // Determine if we're resuming or starting fresh
+        bool resuming = existingBytes > 0 && response.StatusCode == System.Net.HttpStatusCode.PartialContent;
+        if (existingBytes > 0 && !resuming)
+        {
+            // Server doesn't support Range — restart from scratch
+            log("Server does not support Range requests. Restarting download from scratch.");
+            existingBytes = 0;
+        }
+
         var totalBytes = response.Content.Headers.ContentLength;
-        log($"Content-Length: {(totalBytes.HasValue ? $"{totalBytes.Value / 1024 / 1024} MB" : "unknown")}");
+        var totalExpected = resuming ? existingBytes + totalBytes : totalBytes;
+        log($"Content-Length: {(totalBytes.HasValue ? $"{totalBytes.Value / 1024 / 1024} MB" : "unknown")}" +
+            (resuming ? $" (resuming from {existingBytes / 1024 / 1024} MB)" : ""));
 
         using var contentStream = await response.Content.ReadAsStreamAsync(ct);
-        using var fileStream = new FileStream(destinationPath, FileMode.Create, FileAccess.Write, FileShare.None, BufferSize, useAsync: true);
+        // Append if resuming, create new otherwise
+        using var fileStream = new FileStream(
+            destinationPath,
+            resuming ? FileMode.Append : FileMode.Create,
+            FileAccess.Write, FileShare.None, BufferSize, useAsync: true);
 
         var buffer = new byte[BufferSize];
-        long totalRead = 0;
+        long totalRead = existingBytes;
         int bytesRead;
         var lastReport = DateTimeOffset.UtcNow;
 
@@ -109,8 +146,8 @@ internal static class ModelDownloader
             // Report progress every 5 seconds
             if (DateTimeOffset.UtcNow - lastReport > TimeSpan.FromSeconds(5))
             {
-                if (totalBytes.HasValue)
-                    log($"Progress: {totalRead / 1024 / 1024} MB / {totalBytes.Value / 1024 / 1024} MB ({100.0 * totalRead / totalBytes.Value:F1}%)");
+                if (totalExpected.HasValue)
+                    log($"Progress: {totalRead / 1024 / 1024} MB / {totalExpected.Value / 1024 / 1024} MB ({100.0 * totalRead / totalExpected.Value:F1}%)");
                 else
                     log($"Progress: {totalRead / 1024 / 1024} MB downloaded");
                 lastReport = DateTimeOffset.UtcNow;


### PR DESCRIPTION
Closes #1

## Summary
Large model downloads that fail mid-transfer can now resume from where they left off instead of restarting from zero.

## Changes
- **ModelDownloader**: sends \Range: bytes={offset}-\ header when partial file exists; appends on \206 Partial Content\; gracefully falls back to full download on \200 OK\; handles \416 Range Not Satisfiable\ by deleting corrupt partial file
- **ModelCache**: new \FindPartialFile()\ and \CleanPartialFiles()\ helpers
- Partial files are **preserved** on transient failures for resume on retry
- No behavior change for \ile://\ URLs (always copied fresh)

## Edge cases handled
- Server returns \200\ instead of \206\  restart from scratch
- Partial file larger than expected  delete and restart
- \416\ response  corrupt partial deleted
