### PR TITLE
Add NativeAOT and trimming compatibility

### DIFF
--- a/ModelPackages.slnx
+++ b/ModelPackages.slnx
@@ -6,6 +6,7 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/ModelPackages.Tests/ModelPackages.Tests.csproj" />
+    <Project Path="tests/AotTest/AotTest.csproj" />
   </Folder>
   <Folder Name="/samples/onnx/">
     <Project Path="samples/SampleModelPackage.Onnx/SampleModelPackage.Onnx.csproj" />

--- a/src/ModelPackages/ModelPackages.csproj
+++ b/src/ModelPackages/ModelPackages.csproj
@@ -5,6 +5,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
+    <IsTrimmable>true</IsTrimmable>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <IsAotCompatible>true</IsAotCompatible>
     <PackageId>ModelPackages</PackageId>
     <Description>Core SDK for building model packages — fetch, cache, and verify AI model artifacts from configurable sources.</Description>
     <PackageReadmeFile>PACKAGE.md</PackageReadmeFile>

--- a/tests/AotTest/AotTest.csproj
+++ b/tests/AotTest/AotTest.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ModelPackages\ModelPackages.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="test-manifest.json" />
+  </ItemGroup>
+
+</Project>

--- a/tests/AotTest/Program.cs
+++ b/tests/AotTest/Program.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using ModelPackages;
+
+// Exercise key ModelPackages APIs to verify they work under NativeAOT.
+Console.WriteLine("=== NativeAOT Compatibility Test ===");
+
+// 1. Load manifest from embedded resource
+var package = ModelPackage.FromManifestResource(Assembly.GetExecutingAssembly(), "AotTest.test-manifest.json");
+Console.WriteLine("✓ FromManifestResource succeeded");
+
+// 2. Get model info (no download)
+var info = await package.GetModelInfoAsync(new ModelOptions
+{
+    Source = "test-direct",
+    Logger = msg => Console.WriteLine($"  [log] {msg}")
+});
+Console.WriteLine($"✓ GetModelInfoAsync: {info.ModelId} rev={info.Revision}");
+Console.WriteLine($"  Source: {info.ResolvedSource}");
+Console.WriteLine($"  Path:   {info.LocalPath}");
+
+// 3. Verify ModelOptions creation
+var options = new ModelOptions
+{
+    Source = "test-direct",
+    CacheDirOverride = Path.GetTempPath(),
+    ForceRedownload = false,
+    Logger = _ => { }
+};
+Console.WriteLine($"✓ ModelOptions created: CacheDirOverride={options.CacheDirOverride}");
+
+// 4. Clear cache (no-op but exercises the code path)
+package.ClearCache(options);
+Console.WriteLine("✓ ClearCache succeeded");
+
+Console.WriteLine();
+Console.WriteLine("All NativeAOT compatibility checks passed.");
+return 0;

--- a/tests/AotTest/test-manifest.json
+++ b/tests/AotTest/test-manifest.json
@@ -1,0 +1,20 @@
+{
+  "model": {
+    "id": "test-org/aot-test-model",
+    "revision": "v1",
+    "files": [
+      {
+        "path": "model.bin",
+        "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "size": 0
+      }
+    ]
+  },
+  "sources": {
+    "test-direct": {
+      "type": "direct",
+      "url": "file:///dev/null"
+    }
+  },
+  "defaultSource": "test-direct"
+}


### PR DESCRIPTION
Closes #10

## Summary
Enables trimming analysis and verifies the Core SDK works correctly under .NET's `PublishTrimmed` and `PublishAot` modes.

## Changes
- **ModelPackages.csproj**: added `IsTrimmable=true`, `EnableTrimAnalyzer=true`, `IsAotCompatible=true`  **zero trim warnings** (source-gen JSON serialization is already trim-safe)
- **New `tests/AotTest/` project**: exercises `FromManifestResource`, `GetModelInfoAsync`, `ClearCache` under `PublishAot=true`

## Verification
- Build with trim analyzer: **0 warnings, 0 errors**
- `dotnet run` of AotTest: all runtime checks pass
- NativeAOT native linking requires C++ Desktop workload (CI needs the workload installed)

## Dependency note
Should be merged last  audit after all other changes are in.
