### PR TITLE
Add cache purge and orphan management

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -104,13 +104,70 @@ $ model-packages clear-cache --manifest samples/SampleModelPackage.Onnx/model-ma
 Cache cleared.
 ```
 
+### `cache-info`
+
+Shows cache usage, tracked entries, and orphaned file counts. Does not require `--manifest`.
+
+```bash
+model-packages cache-info [--cache-dir <path>]
+```
+
+**Example:**
+```bash
+$ model-packages cache-info
+Cache directory: /home/user/.cache/modelpackages
+Total size:      1.2 GB
+Max size:        unlimited
+Entries:         11 file(s)
+Orphaned:        8 file(s), 1.9 GB (run purge-cache --orphans-only to reclaim)
+
+  microsoft/speecht5_tts/main/encoder_model.onnx               326.9 MB  Last used: 2 days ago
+  ...
+```
+
+### `purge-cache`
+
+Deletes cache files. By default deletes the entire cache directory. Use `--orphans-only` to only remove files not tracked by the cache index.
+
+```bash
+model-packages purge-cache [--orphans-only] [--yes] [--cache-dir <path>]
+```
+
+| Flag | Description |
+|---|---|
+| `--orphans-only` | Only delete files on disk that are not tracked by the cache index |
+| `--yes`, `-y` | Skip confirmation — required to actually delete files |
+
+**Preview what would be deleted (dry run):**
+```bash
+$ model-packages purge-cache --orphans-only
+Found 8 orphaned file(s) (1.9 GB):
+  distilbert/.../main/onnx/model.onnx                            255.5 MB
+  ...
+Run with --yes to delete these files.
+```
+
+**Delete orphans:**
+```bash
+$ model-packages purge-cache --orphans-only --yes
+Purged orphaned files. Reclaimed 1.9 GB.
+```
+
+**Full cache wipe:**
+```bash
+$ model-packages purge-cache --yes
+Cache purged. Reclaimed 3.1 GB.
+```
+
 ## Global Options
 
 | Option | Description |
 |---|---|
-| `--manifest <path>` | **(Required)** Path to a `model-manifest.json` file |
+| `--manifest <path>` | **(Required for most commands)** Path to a `model-manifest.json` file |
 | `--source <name\|url>` | Override the model source. Can be a named source (e.g., `company-mirror`) or a direct URL (e.g., `https://...` or `file:///...`) |
 | `--cache-dir <path>` | Override the default cache directory |
+| `--orphans-only` | `purge-cache` only: delete untracked files instead of entire cache |
+| `--yes`, `-y` | `purge-cache` only: skip confirmation prompt |
 | `--help`, `-h` | Show usage information |
 
 ## Exit Codes

--- a/src/ModelPackages.Tool/Program.cs
+++ b/src/ModelPackages.Tool/Program.cs
@@ -21,6 +21,8 @@ static async Task<int> RunAsync(string[] args)
     string? manifest = null;
     string? source = null;
     string? cacheDir = null;
+    bool orphansOnly = false;
+    bool yes = false;
 
     for (int i = 1; i < args.Length; i++)
     {
@@ -34,6 +36,12 @@ static async Task<int> RunAsync(string[] args)
                 break;
             case "--cache-dir" when i + 1 < args.Length:
                 cacheDir = args[++i];
+                break;
+            case "--orphans-only":
+                orphansOnly = true;
+                break;
+            case "--yes" or "-y":
+                yes = true;
                 break;
             default:
                 Console.Error.WriteLine($"Unknown argument: {args[i]}");
@@ -54,6 +62,11 @@ static async Task<int> RunAsync(string[] args)
     {
         CacheInfo(options);
         return 0;
+    }
+
+    if (command == "purge-cache")
+    {
+        return PurgeCache(options, orphansOnly, yes);
     }
 
     if (manifest is null)
@@ -172,6 +185,13 @@ static void CacheInfo(ModelOptions options)
     Console.WriteLine($"Max size:        {(maxSize.HasValue ? FormatSize(maxSize.Value) + " (configured)" : "unlimited")}");
     Console.WriteLine($"Entries:         {index.Entries.Count} file(s)");
 
+    var orphans = index.FindOrphanedFiles(cacheDir);
+    if (orphans.Count > 0)
+    {
+        var orphanTotal = orphans.Sum(o => o.SizeBytes);
+        Console.WriteLine($"Orphaned:        {orphans.Count} file(s), {FormatSize(orphanTotal)} (run purge-cache --orphans-only to reclaim)");
+    }
+
     if (index.Entries.Count > 0)
     {
         Console.WriteLine();
@@ -184,6 +204,65 @@ static void CacheInfo(ModelOptions options)
             Console.WriteLine($"  {entry.Path,-60} {FormatSize(entry.SizeBytes),10}  Last used: {agoStr}");
         }
     }
+}
+
+static int PurgeCache(ModelOptions options, bool orphansOnly, bool confirmed)
+{
+    var cacheDir = ModelPackage.GetCacheDirectory(options);
+
+    if (!Directory.Exists(cacheDir))
+    {
+        Console.WriteLine("Cache directory does not exist. Nothing to purge.");
+        return 0;
+    }
+
+    if (orphansOnly)
+    {
+        var index = ModelPackage.GetCacheInfo(options);
+        var orphans = index.FindOrphanedFiles(cacheDir);
+        if (orphans.Count == 0)
+        {
+            Console.WriteLine("No orphaned files found.");
+            return 0;
+        }
+
+        var orphanTotal = orphans.Sum(o => o.SizeBytes);
+        Console.WriteLine($"Found {orphans.Count} orphaned file(s) ({FormatSize(orphanTotal)}):");
+        foreach (var (path, size) in orphans.OrderByDescending(o => o.SizeBytes))
+            Console.WriteLine($"  {path,-60} {FormatSize(size),10}");
+
+        if (!confirmed)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Run with --yes to delete these files.");
+            return 0;
+        }
+
+        var reclaimed = ModelPackage.PurgeOrphanedFiles(options, msg => Console.Error.WriteLine(msg));
+        Console.WriteLine($"Purged orphaned files. Reclaimed {FormatSize(reclaimed)}.");
+        return 0;
+    }
+
+    // Full purge
+    long totalSize = 0;
+    foreach (var file in Directory.EnumerateFiles(cacheDir, "*", SearchOption.AllDirectories))
+    {
+        try { totalSize += new FileInfo(file).Length; } catch { }
+    }
+
+    Console.WriteLine($"Cache directory: {cacheDir}");
+    Console.WriteLine($"Total size:      {FormatSize(totalSize)}");
+
+    if (!confirmed)
+    {
+        Console.WriteLine();
+        Console.WriteLine("This will delete the ENTIRE cache directory. Run with --yes to proceed.");
+        return 0;
+    }
+
+    var purged = ModelPackage.PurgeAllCache(options, msg => Console.Error.WriteLine(msg));
+    Console.WriteLine($"Cache purged. Reclaimed {FormatSize(purged)}.");
+    return 0;
 }
 
 static string FormatSize(long bytes)
@@ -208,11 +287,14 @@ static void PrintUsage()
           info          Show resolved source, cache path, manifest metadata
           clear-cache   Remove cached model
           cache-info    Show cache usage and entries (no --manifest required)
+          purge-cache   Delete cache files (no --manifest required)
 
         Options:
           --manifest <path>    Path to model-manifest.json (required for most commands)
           --source <name|url>  Override model source
           --cache-dir <path>   Override cache directory
+          --orphans-only       purge-cache: only delete files not tracked by the cache index
+          --yes, -y            purge-cache: skip confirmation prompt
 
         Exit codes:
           0  Success

--- a/src/ModelPackages/CacheIndex.cs
+++ b/src/ModelPackages/CacheIndex.cs
@@ -76,6 +76,7 @@ public sealed class CacheIndex
     }
 
     /// <summary>Returns total cache size in bytes.</summary>
+    [JsonIgnore]
     public long TotalSizeBytes => Entries.Sum(e => e.SizeBytes);
 
     /// <summary>
@@ -136,6 +137,82 @@ public sealed class CacheIndex
             var fullPath = Path.Combine(cacheDir, e.Path.Replace('/', Path.DirectorySeparatorChar));
             return !File.Exists(fullPath);
         });
+    }
+
+    /// <summary>
+    /// Discovers files on disk that are not tracked by the cache index.
+    /// Returns a list of (relativePath, sizeBytes) for each orphaned file.
+    /// Excludes sidecar (.sha256), lock (.lock), partial (.partial.*), and the index file itself.
+    /// </summary>
+    public List<(string RelativePath, long SizeBytes)> FindOrphanedFiles(string cacheDir)
+    {
+        var orphans = new List<(string, long)>();
+        if (!Directory.Exists(cacheDir))
+            return orphans;
+
+        var trackedPaths = new HashSet<string>(
+            Entries.Select(e => e.Path),
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var file in Directory.EnumerateFiles(cacheDir, "*", SearchOption.AllDirectories))
+        {
+            var name = Path.GetFileName(file);
+
+            // Skip metadata files
+            if (name.Equals(IndexFileName, StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (file.EndsWith(".sha256", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (file.EndsWith(".lock", StringComparison.OrdinalIgnoreCase))
+                continue;
+            if (name.Contains(".partial.", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var relativePath = Path.GetRelativePath(cacheDir, file).Replace(Path.DirectorySeparatorChar, '/');
+            if (!trackedPaths.Contains(relativePath))
+                orphans.Add((relativePath, new FileInfo(file).Length));
+        }
+
+        return orphans;
+    }
+
+    /// <summary>
+    /// Deletes orphaned files (on disk but not in the index), their sidecars, and empty directories.
+    /// Returns the total bytes reclaimed.
+    /// </summary>
+    public long PurgeOrphans(string cacheDir, Action<string>? log = null)
+    {
+        var orphans = FindOrphanedFiles(cacheDir);
+        long reclaimed = 0;
+
+        foreach (var (relativePath, sizeBytes) in orphans)
+        {
+            var fullPath = Path.Combine(cacheDir, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            try
+            {
+                if (File.Exists(fullPath))
+                {
+                    File.Delete(fullPath);
+                    reclaimed += sizeBytes;
+                    log?.Invoke($"Deleted orphan: {relativePath} ({sizeBytes / 1024 / 1024} MB)");
+                }
+
+                // Clean sidecar if present
+                var sidecar = fullPath + ".sha256";
+                if (File.Exists(sidecar))
+                    File.Delete(sidecar);
+            }
+            catch
+            {
+                // File may be locked — skip
+                continue;
+            }
+        }
+
+        // Clean empty directories
+        ModelCache.CleanEmptyDirectories(cacheDir);
+
+        return reclaimed;
     }
 }
 

--- a/src/ModelPackages/ModelCache.cs
+++ b/src/ModelPackages/ModelCache.cs
@@ -140,6 +140,30 @@ internal static class ModelCache
         }
     }
 
+    /// <summary>
+    /// Removes empty directories under the given root, walking bottom-up.
+    /// Stops at the root directory itself (never deletes it).
+    /// </summary>
+    public static void CleanEmptyDirectories(string rootDir)
+    {
+        if (!Directory.Exists(rootDir))
+            return;
+
+        foreach (var dir in Directory.GetDirectories(rootDir, "*", SearchOption.AllDirectories)
+            .OrderByDescending(d => d.Length)) // deepest first
+        {
+            try
+            {
+                if (Directory.Exists(dir) &&
+                    !Directory.EnumerateFileSystemEntries(dir).Any())
+                {
+                    Directory.Delete(dir);
+                }
+            }
+            catch { }
+        }
+    }
+
     private sealed class LockHandle : IDisposable
     {
         private readonly FileStream _stream;

--- a/src/ModelPackages/ModelPackage.cs
+++ b/src/ModelPackages/ModelPackage.cs
@@ -115,6 +115,16 @@ public sealed class ModelPackage
                 File.Delete(cachePath);
             IntegrityVerifier.DeleteSidecar(cachePath);
         }
+
+        // Update cache index to remove stale entries
+        try
+        {
+            var cacheDir = ModelCache.ResolveCacheDir(options);
+            var index = CacheIndex.Load(cacheDir);
+            index.Reconcile(cacheDir);
+            index.Save(cacheDir);
+        }
+        catch { }
     }
 
     /// <summary>
@@ -136,6 +146,42 @@ public sealed class ModelPackage
     /// <summary>Returns the configured maximum cache size, or null if unlimited.</summary>
     public static long? GetMaxCacheSize()
         => ModelSourceConfig.GetMaxCacheSize();
+
+    /// <summary>
+    /// Deletes cached files that are not tracked by the cache index (orphans).
+    /// Returns the total bytes reclaimed.
+    /// </summary>
+    public static long PurgeOrphanedFiles(ModelOptions? options = null, Action<string>? log = null)
+    {
+        var cacheDir = ModelCache.ResolveCacheDir(options);
+        var index = CacheIndex.Load(cacheDir);
+        index.Reconcile(cacheDir);
+        var reclaimed = index.PurgeOrphans(cacheDir, log);
+        index.Save(cacheDir);
+        return reclaimed;
+    }
+
+    /// <summary>
+    /// Deletes the entire cache directory and all contents.
+    /// Returns the total bytes deleted.
+    /// </summary>
+    public static long PurgeAllCache(ModelOptions? options = null, Action<string>? log = null)
+    {
+        var cacheDir = ModelCache.ResolveCacheDir(options);
+        if (!Directory.Exists(cacheDir))
+            return 0;
+
+        long totalSize = 0;
+        foreach (var file in Directory.EnumerateFiles(cacheDir, "*", SearchOption.AllDirectories))
+        {
+            try { totalSize += new FileInfo(file).Length; } catch { }
+        }
+
+        log?.Invoke($"Deleting entire cache directory: {cacheDir}");
+        Directory.Delete(cacheDir, recursive: true);
+        log?.Invoke($"Reclaimed {totalSize / 1024 / 1024} MB");
+        return totalSize;
+    }
 
     // ── Static utilities ────────────────────────────────────────────
 

--- a/tests/ModelPackages.Tests/CacheTests.cs
+++ b/tests/ModelPackages.Tests/CacheTests.cs
@@ -112,4 +112,177 @@ public class CacheTests : IDisposable
 
         Assert.Contains("v2.1", path);
     }
+
+    // ── CacheIndex tests ─────────────────────────────────────────────
+
+    [Fact]
+    public void Reconcile_RemovesStaleEntries()
+    {
+        var cacheDir = Path.Combine(_tempDir, "cache");
+        Directory.CreateDirectory(cacheDir);
+
+        // Create a file and track it, then delete the file
+        var filePath = Path.Combine(cacheDir, "model.onnx");
+        File.WriteAllBytes(filePath, [1, 2, 3]);
+
+        var index = new CacheIndex();
+        index.Touch("model.onnx", 3);
+        index.Touch("deleted.onnx", 1000);
+        index.Save(cacheDir);
+
+        index.Reconcile(cacheDir);
+
+        Assert.Single(index.Entries);
+        Assert.Equal("model.onnx", index.Entries[0].Path);
+    }
+
+    [Fact]
+    public void FindOrphanedFiles_DiscoversUntrackedFiles()
+    {
+        var cacheDir = Path.Combine(_tempDir, "cache");
+        Directory.CreateDirectory(Path.Combine(cacheDir, "org", "model", "main"));
+
+        // Create tracked and untracked files
+        var tracked = Path.Combine(cacheDir, "org", "model", "main", "tracked.onnx");
+        var orphan = Path.Combine(cacheDir, "org", "model", "main", "orphan.onnx");
+        File.WriteAllBytes(tracked, new byte[100]);
+        File.WriteAllBytes(orphan, new byte[200]);
+
+        var index = new CacheIndex();
+        index.Touch("org/model/main/tracked.onnx", 100);
+
+        var orphans = index.FindOrphanedFiles(cacheDir);
+
+        Assert.Single(orphans);
+        Assert.Equal("org/model/main/orphan.onnx", orphans[0].RelativePath);
+        Assert.Equal(200, orphans[0].SizeBytes);
+    }
+
+    [Fact]
+    public void FindOrphanedFiles_IgnoresMetadataFiles()
+    {
+        var cacheDir = Path.Combine(_tempDir, "cache");
+        Directory.CreateDirectory(cacheDir);
+
+        // Create various metadata files that should be ignored
+        File.WriteAllBytes(Path.Combine(cacheDir, "model.onnx.sha256"), [1]);
+        File.WriteAllBytes(Path.Combine(cacheDir, "model.onnx.lock"), [1]);
+        File.WriteAllBytes(Path.Combine(cacheDir, "model.onnx.partial.abc123"), [1]);
+
+        var index = new CacheIndex();
+        var orphans = index.FindOrphanedFiles(cacheDir);
+
+        Assert.Empty(orphans);
+    }
+
+    [Fact]
+    public void PurgeOrphans_DeletesUntrackedFilesAndSidecars()
+    {
+        var cacheDir = Path.Combine(_tempDir, "cache");
+        Directory.CreateDirectory(Path.Combine(cacheDir, "org", "model"));
+
+        var tracked = Path.Combine(cacheDir, "org", "model", "tracked.onnx");
+        var orphan = Path.Combine(cacheDir, "org", "model", "orphan.onnx");
+        var orphanSidecar = orphan + ".sha256";
+        File.WriteAllBytes(tracked, new byte[100]);
+        File.WriteAllBytes(orphan, new byte[500]);
+        File.WriteAllBytes(orphanSidecar, [1]);
+
+        var index = new CacheIndex();
+        index.Touch("org/model/tracked.onnx", 100);
+
+        var reclaimed = index.PurgeOrphans(cacheDir);
+
+        Assert.Equal(500, reclaimed);
+        Assert.True(File.Exists(tracked));
+        Assert.False(File.Exists(orphan));
+        Assert.False(File.Exists(orphanSidecar));
+    }
+
+    [Fact]
+    public void PurgeOrphans_CleansEmptyDirectories()
+    {
+        var cacheDir = Path.Combine(_tempDir, "cache");
+        var deepDir = Path.Combine(cacheDir, "org", "model", "main");
+        Directory.CreateDirectory(deepDir);
+
+        // Orphan in a deep directory
+        File.WriteAllBytes(Path.Combine(deepDir, "orphan.onnx"), new byte[100]);
+
+        var index = new CacheIndex();
+        index.PurgeOrphans(cacheDir);
+
+        // The empty directories should be cleaned up
+        Assert.False(Directory.Exists(Path.Combine(cacheDir, "org")));
+    }
+
+    [Fact]
+    public void CleanEmptyDirectories_RemovesEmptyButKeepsRoot()
+    {
+        var root = Path.Combine(_tempDir, "cache");
+        var deep = Path.Combine(root, "a", "b", "c");
+        Directory.CreateDirectory(deep);
+
+        // One branch is empty, another has a file
+        var otherDir = Path.Combine(root, "d");
+        Directory.CreateDirectory(otherDir);
+        File.WriteAllBytes(Path.Combine(otherDir, "keep.txt"), [1]);
+
+        ModelCache.CleanEmptyDirectories(root);
+
+        Assert.True(Directory.Exists(root));
+        Assert.False(Directory.Exists(Path.Combine(root, "a")));
+        Assert.True(Directory.Exists(otherDir));
+    }
+
+    [Fact]
+    public void ClearCache_UpdatesIndex()
+    {
+        var cacheDir = Path.Combine(_tempDir, "cache");
+        Directory.CreateDirectory(Path.Combine(cacheDir, "test", "model", "main"));
+
+        var manifest = CreateManifest();
+        var file = manifest.Model.Files[0];
+        var options = new ModelOptions { CacheDirOverride = cacheDir };
+
+        // Create the cached file
+        var cachePath = ModelCache.GetCachePath(manifest, file, options);
+        Directory.CreateDirectory(Path.GetDirectoryName(cachePath)!);
+        File.WriteAllBytes(cachePath, new byte[1024]);
+
+        // Track it in the index
+        var index = new CacheIndex();
+        var relativePath = Path.GetRelativePath(cacheDir, cachePath).Replace(Path.DirectorySeparatorChar, '/');
+        index.Touch(relativePath, 1024);
+        index.Save(cacheDir);
+
+        // ClearCache should delete the file AND update the index
+        var package = ModelPackage.FromManifestStream(
+            new MemoryStream(System.Text.Encoding.UTF8.GetBytes($$"""
+            {
+              "model": { "id": "test/model", "revision": "main", "files": [{ "path": "model.onnx", "sha256": "abc", "size": 1024 }] },
+              "sources": { "hf": { "type": "huggingface" } },
+              "defaultSource": "hf"
+            }
+            """)));
+        package.ClearCache(options);
+
+        // Reload index — entry should be gone
+        var reloaded = CacheIndex.Load(cacheDir);
+        Assert.Empty(reloaded.Entries);
+    }
+
+    [Fact]
+    public void TotalSizeBytes_NotSerializedToJson()
+    {
+        var cacheDir = Path.Combine(_tempDir, "cache");
+        Directory.CreateDirectory(cacheDir);
+
+        var index = new CacheIndex();
+        index.Touch("file.onnx", 1024);
+        index.Save(cacheDir);
+
+        var json = File.ReadAllText(Path.Combine(cacheDir, "cache-index.json"));
+        Assert.DoesNotContain("TotalSizeBytes", json, StringComparison.OrdinalIgnoreCase);
+    }
 }


### PR DESCRIPTION
Partially addresses #32

## Summary
Adds cache orphan discovery, purge commands, and index reconciliation improvements.

## Changes

### CacheIndex (`src/ModelPackages/CacheIndex.cs`)
- `FindOrphanedFiles(cacheDir)`  discovers files on disk not tracked by the index (excludes `*.sha256`, `*.lock`, `cache-index.json`)
- `PurgeOrphans(cacheDir, log)`  deletes orphaned files + sidecar files + empty directories
- `[JsonIgnore]` on `TotalSizeBytes` to prevent serialization pollution

### ModelCache (`src/ModelPackages/ModelCache.cs`)
- `CleanEmptyDirectories(directory)`  bottom-up removal of empty directories after purge

### ModelPackage (`src/ModelPackages/ModelPackage.cs`)
- `PurgeOrphanedFiles(options, log)`  static API: reconcile + purge orphans
- `PurgeAllCache(options, log)`  static API: wipe entire cache directory
- `ClearCache` now reconciles the cache index after clearing files

### CLI Tool (`src/ModelPackages.Tool/Program.cs`)
- `purge-cache` command with `--orphans-only` and `--yes`/`-y` flags
- `cache-info` now displays orphaned file count and size

### Tests (`tests/ModelPackages.Tests/CacheTests.cs`)
- 8 new CacheIndex tests: Reconcile, FindOrphanedFiles, PurgeOrphans, metadata filtering, etc.

### Docs
- `docs/cli-reference.md` updated with `purge-cache` documentation

## Issue #32 Coverage
-  Item 2: Orphan discovery (`FindOrphanedFiles`)
-  Item 4: Reconciliation in `ClearCache`
-  Item 1: Inter-process locking (not addressed)
-  Item 3: MaxSizeBytes (not addressed)
-  Item 5: GetMaxCacheSize error handling (not addressed)

## Build & Tests
- Build: 0 errors, 0 warnings
- Tests: 55/55 passed (47 existing + 8 new)