### PR TITLE
Validate ModelPackageClassName as valid C# identifier

### DIFF
--- a/src/ModelPackages.Generators/Diagnostics.cs
+++ b/src/ModelPackages.Generators/Diagnostics.cs
@@ -19,4 +19,12 @@ internal static class Diagnostics
         category: "ModelPackages",
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor InvalidClassName = new(
+        id: "MPKG003",
+        title: "Invalid ModelPackageClassName",
+        messageFormat: "The ModelPackageClassName '{0}' is not a valid C# identifier. It must be a valid identifier and not a language keyword.",
+        category: "ModelPackages",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }

--- a/src/ModelPackages.Generators/ModelPackageGenerator.cs
+++ b/src/ModelPackages.Generators/ModelPackageGenerator.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 
 namespace ModelPackages.Generators;
@@ -37,6 +38,17 @@ public sealed class ModelPackageGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(combined, (spc, pair) =>
         {
             var ((manifestText, className), rootNamespace) = pair;
+
+            // Validate class name is a legal C# identifier
+            var trimmedName = className.Trim();
+            if (trimmedName != DefaultClassName && !SyntaxFacts.IsValidIdentifier(trimmedName))
+            {
+                spc.ReportDiagnostic(Diagnostic.Create(
+                    Diagnostics.InvalidClassName, Location.None, className));
+                return;
+            }
+            className = trimmedName;
+
             var content = manifestText.GetText(spc.CancellationToken)?.ToString();
             if (string.IsNullOrWhiteSpace(content))
             {


### PR DESCRIPTION
Closes #34

## Summary
Validates `ModelPackageClassName` MSBuild property as a valid C# identifier before using it in generated code.

## Changes

### `Diagnostics.cs`
- New `MPKG003` diagnostic: "The ModelPackageClassName '{0}' is not a valid C# identifier."

### `ModelPackageGenerator.cs`
- Trim whitespace from class name before use
- Call `SyntaxFacts.IsValidIdentifier()` to validate
- Report `MPKG003` and skip generation if invalid
- Default class name (`ModelPackageApi`) is exempted from validation (always valid)

## What this catches
- C# keywords (`class`, `static`, `void`)
- Names with spaces or special characters (`My Class`, `foo-bar`)
- Whitespace-only values
- Empty strings (after trim)

## Build & Tests
- Build: 0 errors, 0 warnings
- Tests: 59/59 passed (no generator test project exists; validation is compile-time)