### PR TITLE
Test robustness: parallelism safety, config isolation, fast retries

### DIFF
--- a/src/ModelPackages/ModelDownloader.cs
+++ b/src/ModelPackages/ModelDownloader.cs
@@ -9,6 +9,10 @@ internal static class ModelDownloader
     private const int MaxRetries = 3;
     private const int BufferSize = 81920; // 80KB chunks
 
+    /// <summary>Override in tests to eliminate retry delays.</summary>
+    internal static Func<int, TimeSpan> RetryDelayFactory { get; set; } =
+        attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt));
+
     private static HttpClient CreateClient()
     {
         var handler = new HttpClientHandler { AllowAutoRedirect = true };
@@ -51,7 +55,7 @@ internal static class ModelDownloader
             }
             catch (HttpRequestException ex) when (attempt < MaxRetries && IsTransient(ex))
             {
-                var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt));
+                var delay = RetryDelayFactory(attempt);
                 log($"Download attempt {attempt} failed ({ex.Message}). Retrying in {delay.TotalSeconds}s...");
                 await Task.Delay(delay, ct);
                 // Partial file is preserved for resume on next attempt

--- a/tests/ModelPackages.Tests/CacheTests.cs
+++ b/tests/ModelPackages.Tests/CacheTests.cs
@@ -2,6 +2,7 @@ using Xunit;
 
 namespace ModelPackages.Tests;
 
+[Collection("EnvVarTests")]
 public class CacheTests : IDisposable
 {
     private readonly string _tempDir;

--- a/tests/ModelPackages.Tests/DownloaderTests.cs
+++ b/tests/ModelPackages.Tests/DownloaderTests.cs
@@ -8,17 +8,21 @@ public class DownloaderTests : IAsyncLifetime
 {
     private MockModelServer _server = null!;
     private string _tempDir = null!;
+    private Func<int, TimeSpan>? _prevRetryDelay;
 
     public async Task InitializeAsync()
     {
         _server = new MockModelServer();
         _tempDir = Path.Combine(Path.GetTempPath(), "dl-test-" + Guid.NewGuid().ToString("N")[..8]);
         Directory.CreateDirectory(_tempDir);
+        _prevRetryDelay = ModelDownloader.RetryDelayFactory;
+        ModelDownloader.RetryDelayFactory = _ => TimeSpan.Zero;
         await Task.CompletedTask;
     }
 
     public async Task DisposeAsync()
     {
+        ModelDownloader.RetryDelayFactory = _prevRetryDelay!;
         await _server.DisposeAsync();
         try { Directory.Delete(_tempDir, recursive: true); } catch { }
     }

--- a/tests/ModelPackages.Tests/EnvVarTestCollection.cs
+++ b/tests/ModelPackages.Tests/EnvVarTestCollection.cs
@@ -6,7 +6,7 @@ namespace ModelPackages.Tests;
 /// Serializes test classes that mutate process-level environment variables.
 /// xUnit runs tests in parallel by default; env var mutations are not parallel-safe.
 /// </summary>
-[CollectionDefinition("EnvVarTests")]
+[CollectionDefinition("EnvVarTests", DisableParallelization = true)]
 public class EnvVarTestCollection : ICollectionFixture<EnvVarTestCollection.Marker>
 {
     public class Marker { }

--- a/tests/ModelPackages.Tests/EnvVarTestCollection.cs
+++ b/tests/ModelPackages.Tests/EnvVarTestCollection.cs
@@ -1,0 +1,13 @@
+using Xunit;
+
+namespace ModelPackages.Tests;
+
+/// <summary>
+/// Serializes test classes that mutate process-level environment variables.
+/// xUnit runs tests in parallel by default; env var mutations are not parallel-safe.
+/// </summary>
+[CollectionDefinition("EnvVarTests")]
+public class EnvVarTestCollection : ICollectionFixture<EnvVarTestCollection.Marker>
+{
+    public class Marker { }
+}

--- a/tests/ModelPackages.Tests/SourceResolverTests.cs
+++ b/tests/ModelPackages.Tests/SourceResolverTests.cs
@@ -17,6 +17,7 @@ public class SourceResolverTests
         // Isolate from machine-level config files that could interfere
         var prevHome = Environment.GetEnvironmentVariable("USERPROFILE");
         var prevHomeUnix = Environment.GetEnvironmentVariable("HOME");
+        var prevSource = Environment.GetEnvironmentVariable("MODELPACKAGES_SOURCE");
         var prevDir = Directory.GetCurrentDirectory();
         var tempDir = Path.Combine(Path.GetTempPath(), "resolver-test-" + Guid.NewGuid().ToString("N")[..8]);
         Directory.CreateDirectory(tempDir);
@@ -25,6 +26,7 @@ public class SourceResolverTests
         {
             Environment.SetEnvironmentVariable("USERPROFILE", tempDir);
             Environment.SetEnvironmentVariable("HOME", tempDir);
+            Environment.SetEnvironmentVariable("MODELPACKAGES_SOURCE", null);
             Directory.SetCurrentDirectory(tempDir);
 
             var (url, sourceName) = ModelSourceResolver.Resolve(manifest, file, options: null);
@@ -39,6 +41,7 @@ public class SourceResolverTests
             Directory.SetCurrentDirectory(prevDir);
             Environment.SetEnvironmentVariable("USERPROFILE", prevHome);
             Environment.SetEnvironmentVariable("HOME", prevHomeUnix);
+            Environment.SetEnvironmentVariable("MODELPACKAGES_SOURCE", prevSource);
             try { Directory.Delete(tempDir, recursive: true); } catch { }
         }
     }

--- a/tests/ModelPackages.Tests/SourceResolverTests.cs
+++ b/tests/ModelPackages.Tests/SourceResolverTests.cs
@@ -2,6 +2,7 @@ using Xunit;
 
 namespace ModelPackages.Tests;
 
+[Collection("EnvVarTests")]
 public class SourceResolverTests
 {
     private static ModelManifest LoadFixture() =>
@@ -13,12 +14,33 @@ public class SourceResolverTests
         var manifest = LoadFixture();
         var file = manifest.Model.Files[0];
 
-        var (url, sourceName) = ModelSourceResolver.Resolve(manifest, file, options: null);
+        // Isolate from machine-level config files that could interfere
+        var prevHome = Environment.GetEnvironmentVariable("USERPROFILE");
+        var prevHomeUnix = Environment.GetEnvironmentVariable("HOME");
+        var prevDir = Directory.GetCurrentDirectory();
+        var tempDir = Path.Combine(Path.GetTempPath(), "resolver-test-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(tempDir);
 
-        Assert.Equal("huggingface", sourceName);
-        Assert.Contains("huggingface.co", url);
-        Assert.Contains("sentence-transformers/all-MiniLM-L6-v2", url);
-        Assert.EndsWith("/onnx/model.onnx", url);
+        try
+        {
+            Environment.SetEnvironmentVariable("USERPROFILE", tempDir);
+            Environment.SetEnvironmentVariable("HOME", tempDir);
+            Directory.SetCurrentDirectory(tempDir);
+
+            var (url, sourceName) = ModelSourceResolver.Resolve(manifest, file, options: null);
+
+            Assert.Equal("huggingface", sourceName);
+            Assert.Contains("huggingface.co", url);
+            Assert.Contains("sentence-transformers/all-MiniLM-L6-v2", url);
+            Assert.EndsWith("/onnx/model.onnx", url);
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(prevDir);
+            Environment.SetEnvironmentVariable("USERPROFILE", prevHome);
+            Environment.SetEnvironmentVariable("HOME", prevHomeUnix);
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
     }
 
     [Fact]


### PR DESCRIPTION
Closes #28

## Summary
Fixes three test robustness issues identified in PR #19 code review.

## Changes

### 1. Env var parallelism safety
- New `EnvVarTestCollection.cs` with `[CollectionDefinition("EnvVarTests")]`
- `SourceResolverTests` and `CacheTests` now have `[Collection("EnvVarTests")]`
- Ensures env var mutations don't interfere across parallel xUnit test runs

### 2. Config isolation for `Resolve_NoOverrides`
- Test now overrides `HOME`/`USERPROFILE` to a temp directory
- Saves/restores working directory in a `finally` block
- Test no longer fails on machines with existing `~/.modelpackages/model-sources.json`

### 3. Injectable retry delays
- New `ModelDownloader.RetryDelayFactory` internal static property (default: exponential backoff)
- `DownloaderTests` overrides to `TimeSpan.Zero` and restores in `DisposeAsync`
- **Test suite: 4s  1s** (retry tests no longer sleep 2-4 real seconds)

## Build & Tests
- Build: 0 errors, 0 warnings
- Tests: 59/59 passed (1 second total, down from 4)