### PR TITLE
Cache index robustness: locking, MaxSizeBytes, error handling

### DIFF
--- a/src/ModelPackages/CacheIndex.cs
+++ b/src/ModelPackages/CacheIndex.cs
@@ -7,8 +7,9 @@ namespace ModelPackages;
 public sealed class CacheIndex
 {
     private const string IndexFileName = "cache-index.json";
+    private const string LockFileName = "cache-index.lock";
 
-    [JsonPropertyName("maxSizeBytes")]
+    [JsonIgnore]
     public long? MaxSizeBytes { get; set; }
 
     [JsonPropertyName("entries")]
@@ -36,6 +37,7 @@ public sealed class CacheIndex
 
         try
         {
+            using var _ = AcquireIndexLock(cacheDir);
             var json = File.ReadAllText(indexPath);
             return JsonSerializer.Deserialize(json, CacheIndexJsonContext.Default.CacheIndex)
                 ?? new CacheIndex();
@@ -51,9 +53,48 @@ public sealed class CacheIndex
     {
         Directory.CreateDirectory(cacheDir);
         var indexPath = System.IO.Path.Combine(cacheDir, IndexFileName);
-        var json = JsonSerializer.Serialize(this, CacheIndexJsonContext.Default.CacheIndex);
-        File.WriteAllText(indexPath, json);
+        var tempPath = indexPath + ".tmp." + Guid.NewGuid().ToString("N")[..8];
+
+        try
+        {
+            using var _ = AcquireIndexLock(cacheDir);
+            var json = JsonSerializer.Serialize(this, CacheIndexJsonContext.Default.CacheIndex);
+            File.WriteAllText(tempPath, json);
+            File.Move(tempPath, indexPath, overwrite: true);
+        }
+        catch
+        {
+            try { File.Delete(tempPath); } catch { }
+            throw;
+        }
     }
+
+    /// <summary>Acquires a lock file for cache-index.json access.</summary>
+    private static IDisposable AcquireIndexLock(string cacheDir)
+    {
+        Directory.CreateDirectory(cacheDir);
+        var lockPath = System.IO.Path.Combine(cacheDir, LockFileName);
+        const int maxAttempts = 50;
+        const int delayMs = 100;
+
+        for (int i = 0; i < maxAttempts; i++)
+        {
+            try
+            {
+                var fs = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+                return fs;
+            }
+            catch (IOException) when (i < maxAttempts - 1)
+            {
+                Thread.Sleep(delayMs);
+            }
+        }
+
+        // Last resort: proceed without lock
+        return new NoOpDisposable();
+    }
+
+    private sealed class NoOpDisposable : IDisposable { public void Dispose() { } }
 
     /// <summary>Records or updates a file entry in the index.</summary>
     public void Touch(string relativePath, long sizeBytes)

--- a/src/ModelPackages/ModelSourceConfig.cs
+++ b/src/ModelPackages/ModelSourceConfig.cs
@@ -125,20 +125,34 @@ internal static class ModelSourceConfig
         var userFile = Path.Combine(userDir, FileName);
         if (File.Exists(userFile))
         {
-            var json = File.ReadAllText(userFile);
-            var file = JsonSerializer.Deserialize(json, JsonContext.Default.ModelSourcesFile);
-            if (file?.Cache?.MaxSizeBytes.HasValue == true)
-                maxSize = file.Cache.MaxSizeBytes;
+            try
+            {
+                var json = File.ReadAllText(userFile);
+                var file = JsonSerializer.Deserialize(json, JsonContext.Default.ModelSourcesFile);
+                if (file?.Cache?.MaxSizeBytes.HasValue == true)
+                    maxSize = file.Cache.MaxSizeBytes;
+            }
+            catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
+            {
+                // Malformed or inaccessible config — treat as no max configured
+            }
         }
 
         var dir = projectDir ?? Directory.GetCurrentDirectory();
         var projectFile = Path.Combine(dir, FileName);
         if (File.Exists(projectFile))
         {
-            var json = File.ReadAllText(projectFile);
-            var file = JsonSerializer.Deserialize(json, JsonContext.Default.ModelSourcesFile);
-            if (file?.Cache?.MaxSizeBytes.HasValue == true)
-                maxSize = file.Cache.MaxSizeBytes;
+            try
+            {
+                var json = File.ReadAllText(projectFile);
+                var file = JsonSerializer.Deserialize(json, JsonContext.Default.ModelSourcesFile);
+                if (file?.Cache?.MaxSizeBytes.HasValue == true)
+                    maxSize = file.Cache.MaxSizeBytes;
+            }
+            catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
+            {
+                // Malformed or inaccessible config — treat as no max configured
+            }
         }
 
         return maxSize;


### PR DESCRIPTION
Addresses remaining items in #32 (items 1, 3, 5). Combined with PR #44 (items 2, 4), this fully addresses #32.

## Summary
Three cache index robustness improvements identified in PR #25 code review.

## Changes

### 1. Inter-process locking for cache-index.json (item 1)
- `Load()` and `Save()` now acquire an exclusive lock file (`cache-index.lock`) before reading/writing
- `Save()` writes to a temp file then atomically renames (prevents corruption on crash)
- Lock uses retry loop (50 attempts  100ms = 5s timeout) with graceful fallback

### 2. MaxSizeBytes cleanup (item 3)
- Added `[JsonIgnore]` to `CacheIndex.MaxSizeBytes`  it was being serialized to JSON but never populated from config
- Eviction already passes `maxSizeBytes` as a parameter; the property was dead weight in the JSON file
- Matches existing `[JsonIgnore]` on `TotalSizeBytes`

### 3. GetMaxCacheSize error handling (item 5)
- Wrapped both config file reads in try/catch for `JsonException`, `IOException`, `UnauthorizedAccessException`
- Malformed `model-sources.json` now returns `null` (no max = unlimited) instead of crashing `cache-info`

## Build & Tests
- Build: 0 errors, 0 warnings
- Tests: 59/59 passed