### PR TITLE
Progress reporting: Failed phase and accurate cached sizes

### DIFF
--- a/src/ModelPackages/ModelDownloader.cs
+++ b/src/ModelPackages/ModelDownloader.cs
@@ -69,6 +69,8 @@ internal static class ModelDownloader
         var progress = options?.Progress;
         var fileName = Path.GetFileName(destinationPath);
 
+        try
+        {
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
 
         // HuggingFace auth: bearer token from options or HF_TOKEN env
@@ -171,6 +173,13 @@ internal static class ModelDownloader
 
         // Don't report Completed here — let ModelPackage report it after verification succeeds
         log($"Download complete: {totalRead / 1024 / 1024} MB");
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception) when (progress != null)
+        {
+            progress.Report(new DownloadProgress(0, null, fileName, DownloadPhase.Failed));
+            throw;
+        }
     }
 
     private static bool IsTransient(HttpRequestException ex)

--- a/src/ModelPackages/ModelDownloader.cs
+++ b/src/ModelPackages/ModelDownloader.cs
@@ -71,108 +71,106 @@ internal static class ModelDownloader
 
         try
         {
-        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
 
-        // HuggingFace auth: bearer token from options or HF_TOKEN env
-        var token = options?.HuggingFaceToken
-            ?? Environment.GetEnvironmentVariable("HF_TOKEN");
-        if (!string.IsNullOrEmpty(token))
-        {
-            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
-        }
-
-        // Resume support: if partial file exists, request remaining bytes
-        long existingBytes = 0;
-        if (File.Exists(destinationPath))
-        {
-            existingBytes = new FileInfo(destinationPath).Length;
-            if (existingBytes > 0)
+            // HuggingFace auth: bearer token from options or HF_TOKEN env
+            var token = options?.HuggingFaceToken
+                ?? Environment.GetEnvironmentVariable("HF_TOKEN");
+            if (!string.IsNullOrEmpty(token))
             {
-                request.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(existingBytes, null);
-                log($"Resuming download from byte {existingBytes}...");
-            }
-        }
-
-        log($"Downloading from {RedactUrl(url)}...");
-
-        using var response = await SharedClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
-
-        if (!response.IsSuccessStatusCode)
-        {
-            var statusCode = (int)response.StatusCode;
-            var message = statusCode switch
-            {
-                401 or 403 => $"HTTP {statusCode}: Authentication failed. Set HF_TOKEN for private HF repos or override MODELPACKAGES_SOURCE.",
-                404 => $"HTTP {statusCode}: Model file not found at {RedactUrl(url)}. Check the manifest source configuration.",
-                416 => $"HTTP {statusCode}: Range not satisfiable for {RedactUrl(url)}. Partial file may be corrupt.",
-                _ => $"HTTP {statusCode}: Download failed from {RedactUrl(url)}."
-            };
-
-            // If Range request fails (416), delete partial and the caller's retry will start fresh
-            if (statusCode == 416 && File.Exists(destinationPath))
-            {
-                File.Delete(destinationPath);
+                request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             }
 
-            progress?.Report(new DownloadProgress(0, null, fileName, DownloadPhase.Failed));
-            throw new HttpRequestException(message, null, response.StatusCode);
-        }
-
-        // Determine if we're resuming or starting fresh
-        bool resuming = existingBytes > 0 && response.StatusCode == System.Net.HttpStatusCode.PartialContent;
-        if (existingBytes > 0 && !resuming)
-        {
-            // Server doesn't support Range — restart from scratch
-            log("Server does not support Range requests. Restarting download from scratch.");
-            existingBytes = 0;
-        }
-
-        var totalBytes = response.Content.Headers.ContentLength;
-        var totalExpected = resuming ? existingBytes + totalBytes : totalBytes;
-        log($"Content-Length: {(totalBytes.HasValue ? $"{totalBytes.Value / 1024 / 1024} MB" : "unknown")}" +
-            (resuming ? $" (resuming from {existingBytes / 1024 / 1024} MB)" : ""));
-
-        using var contentStream = await response.Content.ReadAsStreamAsync(ct);
-        // Append if resuming, create new otherwise
-        using var fileStream = new FileStream(
-            destinationPath,
-            resuming ? FileMode.Append : FileMode.Create,
-            FileAccess.Write, FileShare.None, BufferSize, useAsync: true);
-
-        var buffer = new byte[BufferSize];
-        long totalRead = existingBytes;
-        int bytesRead;
-        var lastReport = DateTimeOffset.UtcNow;
-        var lastLogReport = DateTimeOffset.UtcNow;
-        var minReportInterval = TimeSpan.FromMilliseconds(100);
-
-        progress?.Report(new DownloadProgress(0, totalBytes, fileName, DownloadPhase.Downloading));
-
-        while ((bytesRead = await contentStream.ReadAsync(buffer, ct)) > 0)
-        {
-            await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), ct);
-            totalRead += bytesRead;
-
-            var now = DateTimeOffset.UtcNow;
-            if (now - lastReport > minReportInterval)
+            // Resume support: if partial file exists, request remaining bytes
+            long existingBytes = 0;
+            if (File.Exists(destinationPath))
             {
-                progress?.Report(new DownloadProgress(totalRead, totalBytes, fileName, DownloadPhase.Downloading));
-                lastReport = now;
+                existingBytes = new FileInfo(destinationPath).Length;
+                if (existingBytes > 0)
+                {
+                    request.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(existingBytes, null);
+                    log($"Resuming download from byte {existingBytes}...");
+                }
             }
 
-            // Log text progress every 5 seconds (separate timestamp from IProgress throttling)
-            if (now - lastLogReport > TimeSpan.FromSeconds(5))
-            {
-                if (totalExpected.HasValue)
-                    log($"Progress: {totalRead / 1024 / 1024} MB / {totalExpected.Value / 1024 / 1024} MB ({100.0 * totalRead / totalExpected.Value:F1}%)");
-                else
-                    log($"Progress: {totalRead / 1024 / 1024} MB downloaded");
-                lastLogReport = now;
-            }
-        }
+            log($"Downloading from {RedactUrl(url)}...");
 
-        // Don't report Completed here — let ModelPackage report it after verification succeeds
-        log($"Download complete: {totalRead / 1024 / 1024} MB");
+            using var response = await SharedClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var statusCode = (int)response.StatusCode;
+                var message = statusCode switch
+                {
+                    401 or 403 => $"HTTP {statusCode}: Authentication failed. Set HF_TOKEN for private HF repos or override MODELPACKAGES_SOURCE.",
+                    404 => $"HTTP {statusCode}: Model file not found at {RedactUrl(url)}. Check the manifest source configuration.",
+                    416 => $"HTTP {statusCode}: Range not satisfiable for {RedactUrl(url)}. Partial file may be corrupt.",
+                    _ => $"HTTP {statusCode}: Download failed from {RedactUrl(url)}."
+                };
+
+                // If Range request fails (416), delete partial and the caller's retry will start fresh
+                if (statusCode == 416 && File.Exists(destinationPath))
+                {
+                    File.Delete(destinationPath);
+                }
+                throw new HttpRequestException(message, null, response.StatusCode);
+            }
+
+            // Determine if we're resuming or starting fresh
+            bool resuming = existingBytes > 0 && response.StatusCode == System.Net.HttpStatusCode.PartialContent;
+            if (existingBytes > 0 && !resuming)
+            {
+                // Server doesn't support Range — restart from scratch
+                log("Server does not support Range requests. Restarting download from scratch.");
+                existingBytes = 0;
+            }
+
+            var totalBytes = response.Content.Headers.ContentLength;
+            var totalExpected = resuming ? existingBytes + totalBytes : totalBytes;
+            log($"Content-Length: {(totalBytes.HasValue ? $"{totalBytes.Value / 1024 / 1024} MB" : "unknown")}" +
+                (resuming ? $" (resuming from {existingBytes / 1024 / 1024} MB)" : ""));
+
+            using var contentStream = await response.Content.ReadAsStreamAsync(ct);
+            // Append if resuming, create new otherwise
+            using var fileStream = new FileStream(
+                destinationPath,
+                resuming ? FileMode.Append : FileMode.Create,
+                FileAccess.Write, FileShare.None, BufferSize, useAsync: true);
+
+            var buffer = new byte[BufferSize];
+            long totalRead = existingBytes;
+            int bytesRead;
+            var lastReport = DateTimeOffset.UtcNow;
+            var lastLogReport = DateTimeOffset.UtcNow;
+            var minReportInterval = TimeSpan.FromMilliseconds(100);
+
+            progress?.Report(new DownloadProgress(0, totalBytes, fileName, DownloadPhase.Downloading));
+
+            while ((bytesRead = await contentStream.ReadAsync(buffer, ct)) > 0)
+            {
+                await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), ct);
+                totalRead += bytesRead;
+
+                var now = DateTimeOffset.UtcNow;
+                if (now - lastReport > minReportInterval)
+                {
+                    progress?.Report(new DownloadProgress(totalRead, totalBytes, fileName, DownloadPhase.Downloading));
+                    lastReport = now;
+                }
+
+                // Log text progress every 5 seconds (separate timestamp from IProgress throttling)
+                if (now - lastLogReport > TimeSpan.FromSeconds(5))
+                {
+                    if (totalExpected.HasValue)
+                        log($"Progress: {totalRead / 1024 / 1024} MB / {totalExpected.Value / 1024 / 1024} MB ({100.0 * totalRead / totalExpected.Value:F1}%)");
+                    else
+                        log($"Progress: {totalRead / 1024 / 1024} MB downloaded");
+                    lastLogReport = now;
+                }
+            }
+
+            // Don't report Completed here — let ModelPackage report it after verification succeeds
+            log($"Download complete: {totalRead / 1024 / 1024} MB");
         }
         catch (OperationCanceledException) { throw; }
         catch (Exception) when (progress != null)

--- a/src/ModelPackages/ModelPackage.cs
+++ b/src/ModelPackages/ModelPackage.cs
@@ -288,65 +288,66 @@ public sealed class ModelPackage
 
         // Resolve source URL
         progress?.Report(new DownloadProgress(0, file.Size, fileName, DownloadPhase.Resolving));
-        var (url, sourceName) = ModelSourceResolver.Resolve(_manifest, file, options, log);
-
         try
         {
-        // Acquire lock and download
-        using (await ModelCache.AcquireLockAsync(cachePath, cancellationToken))
-        {
-            // Double-check after acquiring lock (another process may have downloaded)
-            if (!options?.ForceRedownload == true)
+            var (url, sourceName) = ModelSourceResolver.Resolve(_manifest, file, options, log);
+            // Acquire lock and download
+            using (await ModelCache.AcquireLockAsync(cachePath, cancellationToken))
             {
-                if (!forceVerification &&
-                    IntegrityVerifier.QuickValidate(cachePath, file.Sha256, file.Size))
+                // Double-check after acquiring lock (another process may have downloaded)
+                if (!options?.ForceRedownload == true)
                 {
-                    log($"File appeared in cache while waiting for lock: {cachePath}");
-                    UpdateCacheIndex(cachePath, file, options, log);
-                    return cachePath;
-                }
-
-                if (await IntegrityVerifier.IsValidAsync(cachePath, file.Sha256, file.Size, cancellationToken))
-                {
-                    if (!string.IsNullOrEmpty(file.Sha256))
+                    if (!forceVerification &&
+                        IntegrityVerifier.QuickValidate(cachePath, file.Sha256, file.Size))
                     {
-                        try { IntegrityVerifier.WriteSidecar(cachePath, file.Sha256); }
-                        catch (IOException) { }
-                        catch (UnauthorizedAccessException) { }
+                        log($"File appeared in cache while waiting for lock: {cachePath}");
+                        UpdateCacheIndex(cachePath, file, options, log);
+                        return cachePath;
                     }
-                    log($"File appeared in cache while waiting for lock: {cachePath}");
-                    var lockedCachedSize = file.Size ?? new FileInfo(cachePath).Length;
-                    progress?.Report(new DownloadProgress(lockedCachedSize, file.Size ?? lockedCachedSize, fileName, DownloadPhase.Completed));
-                    return cachePath;
+
+                    if (await IntegrityVerifier.IsValidAsync(cachePath, file.Sha256, file.Size, cancellationToken))
+                    {
+                        if (!string.IsNullOrEmpty(file.Sha256))
+                        {
+                            try { IntegrityVerifier.WriteSidecar(cachePath, file.Sha256); }
+                            catch (IOException) { }
+                            catch (UnauthorizedAccessException) { }
+                        }
+                        log($"File appeared in cache while waiting for lock: {cachePath}");
+                        var lockedCachedSize = file.Size ?? new FileInfo(cachePath).Length;
+                        progress?.Report(new DownloadProgress(lockedCachedSize, file.Size ?? lockedCachedSize, fileName, DownloadPhase.Completed));
+                        return cachePath;
+                    }
+                }
+
+                // Atomic download: write to temp, verify, rename
+                await ModelCache.AtomicWriteAsync(cachePath, async tempPath =>
+                {
+                    await ModelDownloader.DownloadAsync(url, tempPath, options, cancellationToken);
+                    progress?.Report(new DownloadProgress(0, file.Size, fileName, DownloadPhase.Verifying));
+                    await IntegrityVerifier.VerifyAsync(tempPath, file.Sha256, file.Size, cancellationToken, log);
+                }, cancellationToken);
+
+                // Write sidecar after successful download and verification (best-effort)
+                if (!string.IsNullOrEmpty(file.Sha256))
+                {
+                    try { IntegrityVerifier.WriteSidecar(cachePath, file.Sha256); }
+                    catch (IOException) { }
+                    catch (UnauthorizedAccessException) { }
                 }
             }
 
-            // Atomic download: write to temp, verify, rename
-            await ModelCache.AtomicWriteAsync(cachePath, async tempPath =>
-            {
-                await ModelDownloader.DownloadAsync(url, tempPath, options, cancellationToken);
-                progress?.Report(new DownloadProgress(0, file.Size, fileName, DownloadPhase.Verifying));
-                await IntegrityVerifier.VerifyAsync(tempPath, file.Sha256, file.Size, cancellationToken, log);
-            }, cancellationToken);
-
-            // Write sidecar after successful download and verification (best-effort)
-            if (!string.IsNullOrEmpty(file.Sha256))
-            {
-                try { IntegrityVerifier.WriteSidecar(cachePath, file.Sha256); }
-                catch (IOException) { }
-                catch (UnauthorizedAccessException) { }
-            }
-        }
-
-        progress?.Report(new DownloadProgress(file.Size ?? 0, file.Size, fileName, DownloadPhase.Completed));
-        log($"File cached at: {cachePath}");
-        UpdateCacheIndex(cachePath, file, options, log);
-        return cachePath;
+            var downloadedSize = file.Size ?? new FileInfo(cachePath).Length;
+            progress?.Report(new DownloadProgress(downloadedSize, file.Size ?? downloadedSize, fileName, DownloadPhase.Completed));
+            log($"File cached at: {cachePath}");
+            UpdateCacheIndex(cachePath, file, options, log);
+            return cachePath;
         }
         catch (OperationCanceledException) { throw; }
-        catch
+        catch (HttpRequestException) { throw; } // Download failures already reported Failed in DownloadCoreAsync
+        catch when (progress != null)
         {
-            progress?.Report(new DownloadProgress(0, file.Size, fileName, DownloadPhase.Failed));
+            progress.Report(new DownloadProgress(0, file.Size, fileName, DownloadPhase.Failed));
             throw;
         }
     }

--- a/src/ModelPackages/ModelPackage.cs
+++ b/src/ModelPackages/ModelPackage.cs
@@ -279,7 +279,8 @@ public sealed class ModelPackage
                     catch (UnauthorizedAccessException) { }
                 }
                 log($"File already cached and verified at: {cachePath}");
-                progress?.Report(new DownloadProgress(file.Size ?? 0, file.Size, fileName, DownloadPhase.Completed));
+                var cachedSize = file.Size ?? new FileInfo(cachePath).Length;
+                progress?.Report(new DownloadProgress(cachedSize, file.Size ?? cachedSize, fileName, DownloadPhase.Completed));
                 UpdateCacheIndex(cachePath, file, options, log);
                 return cachePath;
             }
@@ -289,6 +290,8 @@ public sealed class ModelPackage
         progress?.Report(new DownloadProgress(0, file.Size, fileName, DownloadPhase.Resolving));
         var (url, sourceName) = ModelSourceResolver.Resolve(_manifest, file, options, log);
 
+        try
+        {
         // Acquire lock and download
         using (await ModelCache.AcquireLockAsync(cachePath, cancellationToken))
         {
@@ -312,7 +315,8 @@ public sealed class ModelPackage
                         catch (UnauthorizedAccessException) { }
                     }
                     log($"File appeared in cache while waiting for lock: {cachePath}");
-                    progress?.Report(new DownloadProgress(file.Size ?? 0, file.Size, fileName, DownloadPhase.Completed));
+                    var lockedCachedSize = file.Size ?? new FileInfo(cachePath).Length;
+                    progress?.Report(new DownloadProgress(lockedCachedSize, file.Size ?? lockedCachedSize, fileName, DownloadPhase.Completed));
                     return cachePath;
                 }
             }
@@ -338,6 +342,13 @@ public sealed class ModelPackage
         log($"File cached at: {cachePath}");
         UpdateCacheIndex(cachePath, file, options, log);
         return cachePath;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch
+        {
+            progress?.Report(new DownloadProgress(0, file.Size, fileName, DownloadPhase.Failed));
+            throw;
+        }
     }
 
     /// <summary>Updates the cache index with access time and triggers eviction if needed.</summary>


### PR DESCRIPTION
Closes #30

## Summary
Fixes three progress reporting gaps identified in PR #22 code review.

## Changes

### 1. Failed phase on download exceptions (`ModelDownloader.cs`)
- Wrapped `DownloadCoreAsync` body in try/catch
- Reports `DownloadPhase.Failed` on any exception (except `OperationCanceledException`)
- Re-throws after reporting  existing error handling is preserved

### 2. Failed phase on EnsureFileAsync exceptions (`ModelPackage.cs`)
- Wrapped resolve/download/verify pipeline in try/catch
- Reports `DownloadPhase.Failed` on any non-cancellation exception
- Prevents progress from getting stuck in `Resolving` or `Verifying`

### 3. Accurate cached file sizes (`ModelPackage.cs`)
- When `file.Size` is null in the manifest, `BytesTransferred` now uses `FileInfo.Length` (actual on-disk size)
- Applies to both the initial cache-hit path and the post-lock-acquisition path
- UI consumers no longer see misleading "0 bytes" for cached files

## Build & Tests
- Build: 0 errors, 0 warnings
- Tests: 59/59 passed