### PR TITLE
Resumable downloads: cross-run resume, 416 recovery, Content-Range validation

### DIFF
--- a/src/ModelPackages/ModelDownloader.cs
+++ b/src/ModelPackages/ModelDownloader.cs
@@ -73,10 +73,17 @@ internal static class ModelDownloader
         HashSet<string>? allowedHosts)
     {
         var progress = options?.Progress;
-        var fileName = Path.GetFileName(destinationPath);
+        var fileName = Path.GetFileName(new Uri(url).AbsolutePath);
 
         try
         {
+            long existingBytes = 0;
+            if (File.Exists(destinationPath))
+                existingBytes = new FileInfo(destinationPath).Length;
+
+            // Allow one restart if Range request gets 416 or Content-Range mismatch
+            for (int rangeAttempt = 0; rangeAttempt < 2; rangeAttempt++)
+            {
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
 
             // HuggingFace auth: bearer token from options or HF_TOKEN env
@@ -88,15 +95,10 @@ internal static class ModelDownloader
             }
 
             // Resume support: if partial file exists, request remaining bytes
-            long existingBytes = 0;
-            if (File.Exists(destinationPath))
+            if (existingBytes > 0)
             {
-                existingBytes = new FileInfo(destinationPath).Length;
-                if (existingBytes > 0)
-                {
-                    request.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(existingBytes, null);
-                    log($"Resuming download from byte {existingBytes}...");
-                }
+                request.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(existingBytes, null);
+                log($"Resuming download from byte {existingBytes}...");
             }
 
             log($"Downloading from {RedactUrl(url)}...");
@@ -153,6 +155,16 @@ internal static class ModelDownloader
 
             using (response)
             {
+            // Handle 416 (Range Not Satisfiable): delete partial, restart without Range
+            if ((int)response.StatusCode == 416 && existingBytes > 0 && rangeAttempt == 0)
+            {
+                log("Range request failed (416). Deleting partial file and restarting from scratch.");
+                if (File.Exists(destinationPath))
+                    File.Delete(destinationPath);
+                existingBytes = 0;
+                continue;
+            }
+
             if (!response.IsSuccessStatusCode)
             {
                 var statusCode = (int)response.StatusCode;
@@ -164,16 +176,26 @@ internal static class ModelDownloader
                     _ => $"HTTP {statusCode}: Download failed from {RedactUrl(url)}."
                 };
 
-                // If Range request fails (416), delete partial and the caller's retry will start fresh
-                if (statusCode == 416 && File.Exists(destinationPath))
-                {
-                    File.Delete(destinationPath);
-                }
                 throw new HttpRequestException(message, null, response.StatusCode);
             }
 
             // Determine if we're resuming or starting fresh
             bool resuming = existingBytes > 0 && response.StatusCode == System.Net.HttpStatusCode.PartialContent;
+
+            // Content-Range validation: ensure server is resuming from where we expect
+            if (resuming)
+            {
+                var contentRange = response.Content.Headers.ContentRange;
+                if (contentRange?.From != existingBytes && rangeAttempt == 0)
+                {
+                    log($"Content-Range mismatch (expected from={existingBytes}, got {contentRange}). Restarting from scratch.");
+                    if (File.Exists(destinationPath))
+                        File.Delete(destinationPath);
+                    existingBytes = 0;
+                    continue;
+                }
+            }
+
             if (existingBytes > 0 && !resuming)
             {
                 // Server doesn't support Range — restart from scratch
@@ -227,7 +249,9 @@ internal static class ModelDownloader
 
             // Don't report Completed here — let ModelPackage report it after verification succeeds
             log($"Download complete: {totalRead / 1024 / 1024} MB");
+            return; // Success — downloaded within this range attempt
             } // using (response)
+            } // for rangeAttempt
         }
         catch (OperationCanceledException) { throw; }
         catch (Exception) when (progress != null)

--- a/tests/ModelPackages.Tests/DownloaderTests.cs
+++ b/tests/ModelPackages.Tests/DownloaderTests.cs
@@ -247,4 +247,68 @@ public class DownloaderTests : IAsyncLifetime
 
         Assert.Contains("Too many redirects", ex.Message);
     }
+
+    [Fact]
+    public async Task Download_ResumeFromPartialFile()
+    {
+        var content = new byte[2048];
+        Random.Shared.NextBytes(content);
+        _server.AddRangeFile("models/resume.bin", content);
+
+        var dest = TempFile("resume.bin");
+        // Write the first half as a "partial" file
+        await File.WriteAllBytesAsync(dest, content[..1024]);
+
+        await ModelDownloader.DownloadAsync(
+            $"{_server.BaseUrl}/models/resume.bin",
+            dest,
+            options: null,
+            CancellationToken.None);
+
+        Assert.Equal(content, await File.ReadAllBytesAsync(dest));
+        // Verify Range header was sent
+        var rangeReq = _server.Requests.Last();
+        Assert.Contains("bytes=1024-", rangeReq.RangeHeader);
+    }
+
+    [Fact]
+    public async Task Download_416_RestartsFreshAndSucceeds()
+    {
+        var content = new byte[] { 1, 2, 3, 4, 5 };
+        _server.AddRangeFile("models/stale.bin", content);
+
+        var dest = TempFile("stale.bin");
+        // Write a "stale" partial that's larger than the actual file (triggers 416)
+        await File.WriteAllBytesAsync(dest, new byte[9999]);
+
+        await ModelDownloader.DownloadAsync(
+            $"{_server.BaseUrl}/models/stale.bin",
+            dest,
+            options: null,
+            CancellationToken.None);
+
+        Assert.Equal(content, await File.ReadAllBytesAsync(dest));
+    }
+
+    [Fact]
+    public async Task FindPartialFile_And_CleanPartialFiles()
+    {
+        var content = new byte[2048];
+        Random.Shared.NextBytes(content);
+        _server.AddRangeFile("models/crossrun.bin", content);
+
+        // Simulate a partial file from a previous run
+        var finalPath = TempFile("crossrun.bin");
+        var partialPath = finalPath + ".partial.abcdef1234567890abcdef1234567890";
+        await File.WriteAllBytesAsync(partialPath, content[..512]);
+
+        // FindPartialFile should find the existing partial
+        var found = ModelCache.FindPartialFile(finalPath);
+        Assert.NotNull(found);
+        Assert.Equal(partialPath, found);
+
+        // CleanPartialFiles should remove it
+        ModelCache.CleanPartialFiles(finalPath);
+        Assert.Null(ModelCache.FindPartialFile(finalPath));
+    }
 }

--- a/tests/ModelPackages.Tests/Helpers/MockModelServer.cs
+++ b/tests/ModelPackages.Tests/Helpers/MockModelServer.cs
@@ -32,7 +32,8 @@ internal sealed class MockModelServer : IAsyncDisposable
         _app.MapGet("/{**path}", (HttpContext ctx) =>
         {
             var path = ctx.Request.Path.Value?.TrimStart('/') ?? "";
-            _requests.Add(new RequestRecord(path, ctx.Request.Headers.Authorization.ToString()));
+            _requests.Add(new RequestRecord(path, ctx.Request.Headers.Authorization.ToString(),
+                ctx.Request.Headers.Range.ToString()));
 
             if (_redirects.TryGetValue(path, out var redirect))
             {
@@ -48,6 +49,27 @@ internal sealed class MockModelServer : IAsyncDisposable
             {
                 entry.FailCount--;
                 return Results.StatusCode(entry.FailStatusCode);
+            }
+
+            // Range request support
+            var rangeHeader = ctx.Request.Headers.Range.ToString();
+            if (!string.IsNullOrEmpty(rangeHeader) && entry.SupportsRange)
+            {
+                // Parse "bytes=N-"
+                var rangeStr = rangeHeader.Replace("bytes=", "");
+                var parts = rangeStr.Split('-');
+                if (long.TryParse(parts[0], out var from))
+                {
+                    if (from >= entry.Content.Length)
+                    {
+                        ctx.Response.StatusCode = 416;
+                        return Results.StatusCode(416);
+                    }
+                    var slice = entry.Content[(int)from..];
+                    ctx.Response.StatusCode = 206;
+                    ctx.Response.Headers.ContentRange = $"bytes {from}-{entry.Content.Length - 1}/{entry.Content.Length}";
+                    return Results.Bytes(slice, "application/octet-stream");
+                }
             }
 
             return Results.Bytes(entry.Content, "application/octet-stream");
@@ -77,6 +99,12 @@ internal sealed class MockModelServer : IAsyncDisposable
         _redirects[path] = new RedirectEntry(location, statusCode);
     }
 
+    /// <summary>Register a file that supports HTTP Range requests (206 Partial Content).</summary>
+    public void AddRangeFile(string path, byte[] content)
+    {
+        _files[path] = new FileEntry(content) { SupportsRange = true };
+    }
+
     public async ValueTask DisposeAsync()
     {
         await _app.DisposeAsync();
@@ -87,9 +115,10 @@ internal sealed class MockModelServer : IAsyncDisposable
         public byte[] Content { get; } = content;
         public int FailCount { get; set; }
         public int FailStatusCode { get; set; } = 500;
+        public bool SupportsRange { get; set; }
     }
 
     private sealed record RedirectEntry(string Location, int StatusCode);
 
-    internal sealed record RequestRecord(string Path, string AuthorizationHeader);
+    internal sealed record RequestRecord(string Path, string AuthorizationHeader, string RangeHeader = "");
 }


### PR DESCRIPTION
## Summary

Implements all 4 sub-items from issue #29 for robust resumable downloads across process restarts.

### Changes

**1. Cross-run resume (item 1)**
- \EnsureFileAsync\ now calls \FindPartialFile(cachePath)\ before downloading
- If an existing partial file is found, it's reused as the download destination (resume via Range headers)
- On download failure: partial file is preserved for next run
- On verification failure: partial file is deleted (corrupt data)
- On success: partial is moved to final path, other partials cleaned up

**2. HTTP 416 recovery (item 2)**
- \DownloadCoreAsync\ restructured with a loop that handles 416
- When Range request gets 416 (e.g., stale partial larger than actual file), deletes partial and re-issues without Range
- Recovery is automatic  no user-visible error

**3. Content-Range validation (item 3)**
- On 206 Partial Content, validates \Content-Range.From\ matches expected \xistingBytes\
- On mismatch, deletes partial and restarts from scratch (prevents corruption from misaligned append)

**4. Wire FindPartialFile/CleanPartialFiles (item 4)**
- \FindPartialFile\ called in \EnsureFileAsync\ before download
- \CleanPartialFiles\ called after successful download+verify+move
- \CleanPartialFiles\ also called in \ClearCache\ to clean up orphaned partials

### Testing
- MockModelServer enhanced with Range request support (206 + 416)
- 3 new tests: resume from partial, 416 recovery, FindPartialFile/CleanPartialFiles
- 62/62 tests pass

Closes #29